### PR TITLE
fix vep coordinates in variant ID, 0-base to 1-base

### DIFF
--- a/moPepGen/parser/VEPParser.py
+++ b/moPepGen/parser/VEPParser.py
@@ -179,7 +179,7 @@ class VEPRecord():
                 raise ValueError('No alteration found in this VEP record')
 
         _type = 'SNV' if len(ref) == 1 and len(alt) == 1 else 'INDEL'
-        _id = f'{_type}-{alt_start}-{ref}-{alt}'
+        _id = f'{_type}-{alt_start + 1}-{ref}-{alt}'
 
         try:
             return seqvar.VariantRecord(


### PR DESCRIPTION
The current variant ID in the TVF files parsed from VEP is still 0-based.

Closes #13