### PR TITLE
Adding CHROM description to TVF metadata

### DIFF
--- a/moPepGen/seqvar/TVFMetadata.py
+++ b/moPepGen/seqvar/TVFMetadata.py
@@ -86,6 +86,7 @@ class TVFMetadata():
             f'##reference_index={ref_index}',
             f'##genome_fasta={genome_fasta}',
             f'##annotation_gtf={annotation_gtf}',
+            "##CHROM=<Description='Transcript ID'>",
             *[f'##ALT=<ID={key},Description="{val}">' for key, val in self.alt],
             *info_lines,
         ]


### PR DESCRIPTION
In the TVF file metadata, adding description of the CHROM column, that is actually transcript ID.

Closes #19 