### PR TITLE
adding exploratory analysis for rMATS retained introns

### DIFF
--- a/docs/files/rmats_explore.ipynb
+++ b/docs/files/rmats_explore.ipynb
@@ -18,20 +18,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "source": [
-    "import os\n",
     "import pickle\n",
-    "from dataclasses import dataclass\n",
-    "from typing import List, Iterable"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "source": [
-    "os.chdir('..')\n",
+    "from typing import List\n",
     "from moPepGen import gtf\n",
+    "from moPepGen.parser import RMATSParser\n",
+    "\n",
     "with open('test/files/gencode_36_index/annotation.pickle', 'rb') as fh:\n",
     "    annotation = pickle.load(fh)"
    ],
@@ -47,52 +38,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "source": [
-    "@dataclass\n",
-    "class SkippedExon:\n",
-    "    gene_id: str\n",
-    "    chrom: str\n",
-    "    skipped_exon_start:int\n",
-    "    skipped_exon_end:int\n",
-    "    upstream_exon_start:int\n",
-    "    upstream_exon_end:int\n",
-    "    downstream_exon_start:int\n",
-    "    downstream_exon_end:int"
+    "path = '../rmats/output/CPT0208690010_SE.MATS.JC.txt'\n",
+    "skipped_exons = list(RMATSParser.parse(path, 'SE'))"
    ],
    "outputs": [],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "source": [
-    "skipped_exons = []\n",
-    "with open('../../rmats/output/CPT0208690010_SE.MATS.JC.txt', 'rt') as fh:\n",
-    "    line = next(fh, None)\n",
-    "    line = next(fh, None)\n",
-    "    while line:\n",
-    "        fields = line.rstrip().split('\\t')\n",
-    "        gene_id = fields[1].strip('\"')\n",
-    "        chrom = fields[3]\n",
-    "        skipped_exon_start = int(fields[5])\n",
-    "        skipped_exon_end = int(fields[6])\n",
-    "        upstream_exon_start = int(fields[7])\n",
-    "        upstream_exon_end = int(fields[8])\n",
-    "        downstream_exon_start = int(fields[9])\n",
-    "        downstream_exon_end = int(fields[10])\n",
-    "        record = SkippedExon(gene_id, chrom, skipped_exon_start,\n",
-    "            skipped_exon_end, upstream_exon_start, upstream_exon_end,\n",
-    "            downstream_exon_start, downstream_exon_end)\n",
-    "        skipped_exons.append(record)\n",
-    "        line = next(fh, None)"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 11,
    "source": [
     "results = []\n",
     "i = 0\n",
@@ -117,8 +73,8 @@
     "                if int(exon.location.start) == record.downstream_exon_start:\n",
     "                    skipped = True\n",
     "                    break\n",
-    "                if exon.location.start == record.skipped_exon_start and \\\n",
-    "                        exon.location.end == record.skipped_exon_end:\n",
+    "                if exon.location.start == record.exon_start and \\\n",
+    "                        exon.location.end == record.exon_end:\n",
     "                    exon = next(it, None)\n",
     "                    if not exon:\n",
     "                        continue\n",
@@ -133,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 12,
    "source": [
     "both, neither, skipped_only, retained_only = 0, 0, 0, 0\n",
     "for skipped, retained in results:\n",
@@ -151,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 13,
    "source": [
     "print(f'both:          {both}')\n",
     "print(f'skipped only:  {skipped_only}')\n",
@@ -191,52 +147,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 14,
    "source": [
-    "@dataclass\n",
-    "class AlternativeSplicingSite():\n",
-    "    gene_id: str\n",
-    "    chrom: str\n",
-    "    long_exon_start:int\n",
-    "    long_exon_end:int\n",
-    "    short_exon_start:int\n",
-    "    short_exon_end:int\n",
-    "    flanking_exon_start:int\n",
-    "    flanking_exon_end:int"
+    "path = '../rmats/output/CPT0208690010_A5SS.MATS.JC.txt'\n",
+    "a5ss = list(RMATSParser.parse(path, 'A5SS'))"
    ],
    "outputs": [],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
-   "source": [
-    "a5ss = []\n",
-    "with open('../../rmats/output/CPT0208690010_A5SS.MATS.JC.txt', 'rt') as fh:\n",
-    "    line = next(fh, None)\n",
-    "    line = next(fh, None)\n",
-    "    while line:\n",
-    "        fields = line.rstrip().split('\\t')\n",
-    "        line = next(fh, None)\n",
-    "        gene_id = fields[1].strip('\"')\n",
-    "        chrom = fields[3]\n",
-    "        long_exon_start = int(fields[5])\n",
-    "        long_exon_end = int(fields[6])\n",
-    "        short_exon_start = int(fields[7])\n",
-    "        short_exon_end = int(fields[8])\n",
-    "        flanking_exon_start = int(fields[9])\n",
-    "        flanking_exon_end = int(fields[10])\n",
-    "        record = AlternativeSplicingSite(gene_id, chrom, long_exon_start, long_exon_end,\n",
-    "            short_exon_start, short_exon_end, flanking_exon_start,\n",
-    "            flanking_exon_end)\n",
-    "        a5ss.append(record)"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 15,
    "source": [
     "results = []\n",
     "for record in a5ss:\n",
@@ -273,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 16,
    "source": [
     "both, neither, long_only, short_only = 0, 0, 0, 0\n",
     "for long, short in results:\n",
@@ -291,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 17,
    "source": [
     "print(f'both:       {both}')\n",
     "print(f'long only:  {long_only}')\n",
@@ -331,34 +252,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 18,
    "source": [
-    "a3ss = []\n",
-    "with open('../../rmats/output/CPT0208690010_A3SS.MATS.JC.txt', 'rt') as fh:\n",
-    "    line = next(fh, None)\n",
-    "    line = next(fh, None)\n",
-    "    while line:\n",
-    "        fields = line.rstrip().split('\\t')\n",
-    "        line = next(fh, None)\n",
-    "        gene_id = fields[1].strip('\"')\n",
-    "        chrom = fields[3]\n",
-    "        long_exon_start = int(fields[5])\n",
-    "        long_exon_end = int(fields[6])\n",
-    "        short_exon_start = int(fields[7])\n",
-    "        short_exon_end = int(fields[8])\n",
-    "        flanking_exon_start = int(fields[9])\n",
-    "        flanking_exon_end = int(fields[10])\n",
-    "        record = AlternativeSplicingSite(gene_id, chrom, long_exon_start, long_exon_end,\n",
-    "            short_exon_start, short_exon_end, flanking_exon_start,\n",
-    "            flanking_exon_end)\n",
-    "        a3ss.append(record)"
+    "path = '../rmats/output/CPT0208690010_A3SS.MATS.JC.txt'\n",
+    "a3ss = list(RMATSParser.parse(path, 'A3SS'))"
    ],
    "outputs": [],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 19,
    "source": [
     "results = []\n",
     "for record in a3ss:\n",
@@ -394,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 20,
    "source": [
     "both, neither, long_only, short_only = 0, 0, 0, 0\n",
     "for long, short in results:\n",
@@ -412,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 21,
    "source": [
     "print(f'both:       {both}')\n",
     "print(f'long only:  {long_only}')\n",
@@ -452,57 +356,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 22,
    "source": [
-    "@dataclass\n",
-    "class MutuallyExclusiveExons():\n",
-    "    gene_id: str\n",
-    "    chrom: str\n",
-    "    first_exon_start:int\n",
-    "    first_exon_end:int\n",
-    "    second_exon_start:int\n",
-    "    second_exon_end:int\n",
-    "    upstream_exon_start:int\n",
-    "    upstream_exon_end:int\n",
-    "    downstream_exon_start:int\n",
-    "    downstream_exon_end:int"
+    "path = '../rmats/output/CPT0208690010_MXE.MATS.JC.txt'\n",
+    "mxes = list(RMATSParser.parse(path, 'MXE'))"
    ],
    "outputs": [],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
-   "source": [
-    "mxes = []\n",
-    "with open('../../rmats/output/CPT0208690010_MXE.MATS.JC.txt', 'rt') as fh:\n",
-    "    line = next(fh, None)\n",
-    "    line = next(fh, None)\n",
-    "    while line:\n",
-    "        fields = line.rstrip().split('\\t')\n",
-    "        line = next(fh, None)\n",
-    "        gene_id = fields[1].strip('\"')\n",
-    "        chrom = fields[3]\n",
-    "        first_exon_start = int(fields[5])\n",
-    "        first_exon_end = int(fields[6])\n",
-    "        second_exon_start = int(fields[7])\n",
-    "        second_exon_end = int(fields[8])\n",
-    "        upstream_exon_start = int(fields[9])\n",
-    "        upstream_exon_end = int(fields[10])\n",
-    "        downstream_exon_start = int(fields[11])\n",
-    "        downstream_exon_end = int(fields[12])\n",
-    "        record = MutuallyExclusiveExons(gene_id, chrom, first_exon_start,\n",
-    "            first_exon_end, second_exon_start, second_exon_end,\n",
-    "            upstream_exon_start, upstream_exon_end, downstream_exon_start,\n",
-    "            downstream_exon_end)\n",
-    "        mxes.append(record)"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 23,
    "source": [
     "results = []\n",
     "for record in mxes:\n",
@@ -548,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 24,
    "source": [
     "both, neither, first_only, second_only = 0, 0, 0, 0\n",
     "for i_first, i_second, i_both in results:\n",
@@ -566,7 +430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 25,
    "source": [
     "print(f'both:        {both}')\n",
     "print(f'first only:  {first_only}')\n",
@@ -600,6 +464,237 @@
   {
    "cell_type": "markdown",
    "source": [
+    "## 5. Retained Intron"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "source": [
+    "path = '../rmats/output/CPT0208690010_RI.MATS.JC.txt'\n",
+    "ri = list(RMATSParser.parse(path, 'RI'))"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "source": [
+    "results = []\n",
+    "for record in ri:\n",
+    "    tx_ids = annotation.genes[record.gene_id].transcripts\n",
+    "    tx_models:List[gtf.TranscriptAnnotationModel] = [annotation.transcripts[tx_id] for tx_id in tx_ids]\n",
+    "    spliced, retained = False, False\n",
+    "    for tx in tx_models:\n",
+    "        if spliced and retained:\n",
+    "            break\n",
+    "        it = iter(tx.exon)\n",
+    "        exon = next(it, None)\n",
+    "        while exon:\n",
+    "            if exon.location.start == record.retained_intron_exon_start:\n",
+    "                if exon.location.end == record.retained_intron_exon_end:\n",
+    "                    retained = True\n",
+    "                    exon = next(it, None)\n",
+    "                    continue\n",
+    "                if exon.location.end == record.upstream_exon_end:\n",
+    "                    exon = next(it, None)\n",
+    "                    if not exon:\n",
+    "                        break\n",
+    "                    if exon.location.start == record.downstream_exon_start and \\\n",
+    "                            exon.location.end == record.downstream_exon_end:\n",
+    "                        spliced = True\n",
+    "            exon = next(it, None)\n",
+    "    results.append((spliced, retained))"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "source": [
+    "spliced, retained, neither, both = 0, 0, 0, 0\n",
+    "for result in results:\n",
+    "    if result[0] and result[1]:\n",
+    "        both += 1\n",
+    "    elif result[0]:\n",
+    "        spliced += 1\n",
+    "    elif result[1]:\n",
+    "        retained += 1\n",
+    "    else:\n",
+    "        neither += 1"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "source": [
+    "print(f'both:          {both}')\n",
+    "print(f'spliced only:  {spliced}')\n",
+    "print(f'retained only: {retained}')\n",
+    "print(f'neither:       {neither}')"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "both:          8818\n",
+      "spliced only:  0\n",
+      "retained only: 1303\n",
+      "neither:       3105\n"
+     ]
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "+ 8818 genes has transcripts with the intron both spliced and retained.\n",
+    "+ 0 genes only has transcripts with the intron spliced but not retained.\n",
+    "+ 1303 genes only have transcripts with the intron retained but not spliced.\n",
+    "+ 3105 genes don't have transcripts with either the intron retained or spliced."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "An example of a gene that has only transcript with the target intron retained but not spliced. In this case below, the upstream and downstream exons have 5' or 3' alternative splicing sites. The upstream or downstream exon is also skipped in some transcripts. The start and end of the target intron is indeed valid splicing sites, but they just don't appear together in any of the reported transcript of the gene. So very likely, this is due to the incompleteness of annotation."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "source": [
+    "ri_retained = [i for i, result in enumerate(results) if not result[0] and result[1]]\n",
+    "print(f'ri_exon: {ri[ri_retained[0]].retained_intron_exon_start}-{ri[ri_retained[0]].retained_intron_exon_end}')\n",
+    "print(f'upstream: {ri[ri_retained[0]].upstream_exon_start}-{ri[ri_retained[0]].upstream_exon_end}')\n",
+    "print(f'downstream: {ri[ri_retained[0]].downstream_exon_start}-{ri[ri_retained[0]].downstream_exon_end}')"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "ri_exon: 122518838-122521428\n",
+      "upstream: 122518838-122519051\n",
+      "downstream: 122521384-122521428\n"
+     ]
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "source": [
+    "[', '.join([f'{int(exon.location.start)}-{int(exon.location.end)}' for exon in annotation.transcripts[ex_id].exon]) for ex_id in annotation.genes[ri[ri_retained[0]].gene_id].transcripts]"
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "['122503453-122505706, 122506833-122506923, 122508217-122508447, 122511108-122511188, 122515104-122515227, 122517226-122517430, 122518838-122519029, 122521384-122521428, 122522142-122522299, 122526847-122526936',\n",
+       " '122505058-122505706, 122506833-122506923, 122508217-122508447, 122511108-122511188, 122515104-122515227, 122517226-122517430, 122518838-122519051, 122520503-122520581, 122521384-122521428, 122522142-122522299, 122526847-122526936',\n",
+       " '122505058-122505706, 122506833-122506923, 122508217-122508450, 122511108-122511188, 122515104-122515227, 122517226-122517430, 122518838-122519029, 122520503-122520581, 122521384-122521428, 122522142-122522299, 122526847-122527000',\n",
+       " '122505305-122505706, 122506833-122506923, 122508217-122508450, 122511108-122511188, 122515104-122515227, 122517226-122517430, 122518838-122519029, 122521295-122521428, 122522142-122522299, 122522798-122523756',\n",
+       " '122505329-122505706, 122506833-122506923, 122508217-122508447, 122511108-122511188, 122513766-122513917',\n",
+       " '122505379-122505706, 122508217-122508406',\n",
+       " '122506371-122507253, 122507872-122508366',\n",
+       " '122508249-122508447, 122511108-122511188, 122514711-122514728, 122515104-122515227, 122517226-122517430, 122518838-122519029, 122521384-122521428, 122522142-122522329, 122526847-122526949',\n",
+       " '122508366-122508447, 122511108-122511188, 122515104-122515227, 122517226-122517430, 122518838-122519051, 122520503-122520581, 122521384-122521428, 122526847-122526960',\n",
+       " '122508377-122508447, 122511108-122511188, 122513766-122513874, 122514711-122514728, 122515104-122515227, 122517226-122517430, 122518838-122519028',\n",
+       " '122511110-122511188, 122515104-122515227, 122517230-122517430, 122518838-122519051, 122520503-122520581, 122521384-122521428, 122522142-122522299, 122526847-122526995',\n",
+       " '122514772-122515227, 122517226-122517396',\n",
+       " '122515162-122515227, 122517226-122517430, 122518838-122521428, 122522142-122522299, 122526847-122526987',\n",
+       " '122517235-122517430, 122518838-122519029, 122521384-122521428, 122526847-122526962',\n",
+       " '122518839-122519051, 122520503-122520581, 122521384-122521428, 122522142-122522299, 122522798-122522906, 122526847-122526959',\n",
+       " '122518929-122519029, 122520503-122520581, 122521384-122521428, 122522142-122522442',\n",
+       " '122519442-122519664, 122520140-122520201, 122520503-122520581, 122521384-122521428, 122522142-122522291',\n",
+       " '122519909-122520581, 122521384-122521428, 122522142-122522299, 122526847-122526954',\n",
+       " '122520545-122520581, 122521384-122521428, 122522142-122522299, 122522798-122522906, 122526169-122526293, 122526847-122526940',\n",
+       " '122520977-122521428, 122526847-122526949']"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 32
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "This is an example of a gene that don't have the targt intron retained or spliced. Because the intron retaining even is defined strictly with the exact upstream and downstream exon start and end. In this gene below, the upstream and downstreams are either skipped have alternative splicing sites in each transcripts."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "source": [
+    "ri_neither = [i for i, result in enumerate(results) if not result[0] and not result[1]]\n",
+    "print(f'ri_exon: {ri[ri_neither[0]].retained_intron_exon_start}-{ri[ri_neither[0]].retained_intron_exon_end}')\n",
+    "print(f'upstream: {ri[ri_neither[0]].upstream_exon_start}-{ri[ri_neither[0]].upstream_exon_end}')\n",
+    "print(f'downstream: {ri[ri_neither[0]].downstream_exon_start}-{ri[ri_neither[0]].downstream_exon_end}')"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "ri_exon: 2612937-2613284\n",
+      "upstream: 2612937-2613055\n",
+      "downstream: 2613162-2613284\n"
+     ]
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "source": [
+    "[', '.join([f'{int(exon.location.start)}-{int(exon.location.end)}' for exon in annotation.transcripts[ex_id].exon]) for ex_id in annotation.genes[ri[ri_neither[0]].gene_id].transcripts]"
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "['2611477-2611901, 2612065-2612394',\n",
+       " '2611477-2611901, 2612065-2612113, 2612220-2612812, 2612933-2613146',\n",
+       " '2611477-2611901, 2612065-2612113, 2612220-2612253, 2612692-2612812, 2612933-2613209, 2613796-2614769',\n",
+       " '2611477-2611901, 2612065-2612113, 2612220-2612271, 2612692-2612812, 2612933-2613209, 2613796-2614072, 2614317-2614587, 2614717-2614805',\n",
+       " '2611477-2611901, 2612065-2612113, 2612692-2612812, 2612933-2613209, 2613796-2614072, 2614317-2614587, 2614717-2614805',\n",
+       " '2611477-2611891, 2612692-2612812, 2612933-2613209, 2613796-2614072, 2614317-2614587, 2614717-2614812',\n",
+       " '2611477-2611901, 2612065-2612113, 2612220-2612253, 2612692-2612812, 2612933-2613209, 2613796-2614055, 2614317-2614587, 2614717-2614824',\n",
+       " '2611477-2611901, 2612065-2612113, 2612220-2612253, 2612692-2612812, 2612933-2613209, 2613796-2614072, 2614317-2614587, 2614717-2614849',\n",
+       " '2612066-2612113, 2612220-2612253, 2612692-2612812, 2612933-2613209, 2613796-2614072, 2614317-2614417, 2614536-2614587, 2614717-2614790',\n",
+       " '2612087-2612113, 2612220-2612253, 2612933-2613021',\n",
+       " '2612933-2613209, 2613355-2613424, 2613796-2614072, 2614317-2614587, 2614717-2614792',\n",
+       " '2612937-2613055, 2613162-2613209, 2613796-2614072, 2614317-2614587, 2614717-2614788',\n",
+       " '2612944-2613209, 2613796-2614072, 2614317-2614849',\n",
+       " '2613822-2614587, 2614717-2614809']"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 29
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
     "## Conclusion\n",
     "\n",
     "rMATS is able to call 5 alternative splicing events. They are skipped exons (SE), alternative 5' splicing site, alternative 3' splicing site, mutual exclusive exons and retained intron. Although all alternative slicing sites come from the provided genomic annotation (GTF), not all of the events are included in it. For example for skipped exon, in the example above, there are 14,893 events of which only the exon skipped version is annotated, 4,765 events of which only the exon retained version is annotated. 17,672 events that have both the skipped and retained version, while 43,327 of them have neither skipped or retained version of transcript."
@@ -612,8 +707,8 @@
    "hash": "af147f163332422d80ee9a4cc41c17118608bb9b8d1998eaabcfe4c758b81062"
   },
   "kernelspec": {
-   "display_name": "Python 3.8.5 64-bit ('base': conda)",
-   "name": "python3"
+   "name": "python3",
+   "display_name": "Python 3.8.5 64-bit ('base': conda)"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
There we go. It turns out that for RI (retained introns), most genes have transcript versions with the target intron both retained and spliced. but still a small portion of genes only have the retained version but not spliced. The sample I looked does not have any genes with spliced only, but maybe just a special case. So I think those genes with spliced only and retained only will be interesting to us.

```
both:          8818
spliced only:  0
retained only: 1303
neither:       3105
```

Code review for jupyter notebook is ugly. It's much easier to just look at it with the github normal mode. 
https://github.com/uclahs-cds/private-moPepGen/blob/czhu-update-docs/docs/files/rmats_explore.ipynb

Closes #61 