### PR TITLE
fixing cfg that data was not included correctly during installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
 where = .
 
 [options.package_data]
-moPepGen = moPepGen/data/*
+moPepGen = data/*
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
The setup.cfg wasn't set up correctly, so the data folder wasn't included during installation. It should be fixed now.

Closes #77 