### PR TITLE
Fixing `generateIndex` for ENSEMBL GTF

### DIFF
--- a/moPepGen/gtf/GtfIO.py
+++ b/moPepGen/gtf/GtfIO.py
@@ -33,7 +33,7 @@ class GtfIterator(SequenceIterator):
                 strand=None
 
             attributes = {}
-            attribute_list = [field.strip().split(' ') for field in \
+            attribute_list = [field.strip().split(' ', 1) for field in \
                 fields[8].rstrip(';').split(';')]
             for key,val in attribute_list:
                 val = val.strip('"')


### PR DESCRIPTION
Fixing a bug mentioned in #76 that ENSEMBL GTF failed to read in because spaces are in attribute values.

Closes #76 