### PR TITLE
Ignoring X-containing Peptides when Calling for Noncanonical Peptides

### DIFF
--- a/moPepGen/cli/call_noncoding_peptide.py
+++ b/moPepGen/cli/call_noncoding_peptide.py
@@ -120,7 +120,7 @@ def call_noncoding_peptide(args:argparse.Namespace) -> None:
 
         if args.verbose:
             i += 1
-            if i % 1000 == 0:
+            if i % 5000 == 0:
                 logger(f'{i} transcripts processed.')
 
     noncanonical_pool.write(args.output_fasta)

--- a/moPepGen/svgraph/PeptideVariantGraph.py
+++ b/moPepGen/svgraph/PeptideVariantGraph.py
@@ -557,11 +557,14 @@ class PeptideVariantGraph():
         return peptide_pool
 
 
-def update_peptide_pool(seq, peptide_pool:Set[aa.AminoAcidSeqDict],
+def update_peptide_pool(seq:aa.AminoAcidSeqRecord,
+        peptide_pool:Set[aa.AminoAcidSeqDict],
         label_counter:Set[aa.AminoAcidSeqRecord], label:str,
         update_label:bool=True) -> None:
     """ Add a peptide sequence to a peptide pool if not already exists,
     otherwise update the same peptide's description """
+    if 'X' in seq.seq:
+        return
     if update_label:
         if label not in label_counter:
             label_counter[label] = 0

--- a/test/unit/test_peptide_variant_graph.py
+++ b/test/unit/test_peptide_variant_graph.py
@@ -271,6 +271,16 @@ class TestPeptideVariantGraph(unittest.TestCase):
         seqs_expected = {'LPAQV', 'LPAQQ'}
         self.assertEqual(seqs, seqs_expected)
 
-
-if __name__ == '__main__':
-    unittest.main()
+    def test_call_variant_peptides(self):
+        """ test call peptides """
+        data = {
+            1: ('SSSSK', [0], [None]),
+            2: ('SSSSR', [1],[(0, 3, 'TCT', 'T', 'INDEL', '0:TCT-T', 0, 1, True)]),
+            3: ('SSSIR', [1], [None]),
+            4: ('SSXPK', [2,3], [None])
+        }
+        graph, _ = create_pgraph(data)
+        peptides = graph.call_variant_peptides(1)
+        received = {str(x.seq) for x in peptides}
+        expected = {'SSSSKSSSSR', 'SSSSR'}
+        self.assertEqual(received, expected)


### PR DESCRIPTION
X-containing peptides are not included in the final reported noncanonical peptides, as mentioned in #90

Closes #90 