### PR TITLE
Raise `TranscriptionStopSiteMutationError` correctly on negative strand 

### DIFF
--- a/moPepGen/parser/VEPParser.py
+++ b/moPepGen/parser/VEPParser.py
@@ -147,11 +147,12 @@ class VEPRecord():
             tx_start_genetic = anno.coordinate_genomic_to_gene(tx_first, self.gene)
             tx_end_genetic = anno.coordinate_genomic_to_gene(tx_last, self.gene) + 1
 
-        if alt_end > tx_end_genetic:
-            raise TranscriptionStopSiteMutationError()
         if strand == -1:
             alt_start, alt_end = alt_end, alt_start
         alt_end += 1
+
+        if alt_end > tx_end_genetic:
+            raise TranscriptionStopSiteMutationError()
 
         if self.allele == '-':
             if alt_start == tx_start_genetic:

--- a/test/unit/test_vep.py
+++ b/test/unit/test_vep.py
@@ -342,6 +342,33 @@ class TestVEPRecord(unittest.TestCase):
             vep_record.convert_to_variant_record(anno, genome)
 
     def test_vep_to_variant_record_case12(self):
+        """ Transcriptional stop altering variant on - strand """
+        anno_data = copy.deepcopy(ANNOTATION_DATA)
+        anno_data['genes'][0]['strand'] = -1
+        anno_data['transcripts'][0]['strand'] = -1
+        genome = create_dna_record_dict(GENOME_DATA)
+        anno = create_genomic_annotation(anno_data)
+
+        vep_record = VEPParser.VEPRecord(
+            uploaded_variation='rs55971985',
+            location='chr1:3-8',
+            allele='-',
+            gene='ENSG0001',
+            feature='ENST0001.1',
+            feature_type='Transcript',
+            consequences=['missense_variant'],
+            cdna_position='11',
+            cds_position='11',
+            protein_position=3,
+            amino_acids=('S', 'T'),
+            codons=('aTa', 'aCa'),
+            existing_variation='-',
+            extra={}
+        )
+        with self.assertRaises(TranscriptionStopSiteMutationError):
+            vep_record.convert_to_variant_record(anno, genome)
+
+    def test_vep_to_variant_record_case13(self):
         """ Transcriptional stop altering variant """
         genome = create_dna_record_dict(GENOME_DATA)
         anno = create_genomic_annotation(ANNOTATION_DATA)
@@ -366,7 +393,7 @@ class TestVEPRecord(unittest.TestCase):
         res = record.is_spanning_over_splicing_site(anno, 'ENST0001.1')
         self.assertTrue(res)
 
-    def test_vep_to_variant_record_case13(self):
+    def test_vep_to_variant_record_case14(self):
         """ Test convert vep to variant record with a deletion at the begining
         of the transcript sequence on - strand.
         """
@@ -399,6 +426,7 @@ class TestVEPRecord(unittest.TestCase):
         self.assertEqual(int(variant.location.end), 4)
         self.assertEqual(str(variant.ref), 'GAAG')
         self.assertEqual(str(variant.alt), 'G')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously the `TranscriptionStopSiteMutationError` was not raised correctly on negative strand, as described in #104 . This is fixed now.

Closes #104 