### PR TITLE
Fix callNoncoding when seqname from GTF not found in FASTA

### DIFF
--- a/moPepGen/err.py
+++ b/moPepGen/err.py
@@ -1,4 +1,5 @@
 """ Module for errors """
+from moPepGen import logger
 
 class VariantSourceNotFoundError(Exception):
     """ Error to be raised when the variant source of a peptide is not found """
@@ -23,3 +24,21 @@ class TranscriptionStopSiteMutationError(Exception):
         if transcript_id:
             message += f"transcript [{transcript_id}] "
         super().__init__(message)
+
+class ReferenceSeqnameNotFoundError(Exception):
+    """ Error to be raised when the seqname is not found from the reference
+    genome """
+    raised = False
+    def __init__(self, seqname:str):
+        """ constructor """
+        msg = f"This seqname is not found from the reference genome: {seqname}"
+        super().__init__(msg)
+
+    @classmethod
+    def mute(cls):
+        """ Mute it """
+        cls.raised = True
+
+def warning(msg:str) -> None:
+    """ print a warning message """
+    logger(f"[ !!! moPepGen WARNING !!! ] {msg}")


### PR DESCRIPTION
Print out warning message when the seqname of a GTF record is not found in the reference genome, and then continue. The message is only printed out for once.

```
▶ python -m moPepGen.cli callNoncoding -o test/files/noncoding.fasta --index-dir test/files/ensembl_104_index
[ 2021-09-13 22:13:11 ] moPepGen callNoncoding started
[ 2021-09-13 22:15:32 ] 5000 transcripts processed.
[ 2021-09-13 22:16:45 ] 10000 transcripts processed.
[ 2021-09-13 22:17:33 ] 15000 transcripts processed.
[ 2021-09-13 22:18:51 ] 20000 transcripts processed.
[ 2021-09-13 22:20:17 ] 25000 transcripts processed.
[ 2021-09-13 22:21:42 ] 30000 transcripts processed.
[ 2021-09-13 22:25:13 ] 35000 transcripts processed.
[ 2021-09-13 22:26:52 ] 40000 transcripts processed.
[ 2021-09-13 22:29:12 ] 45000 transcripts processed.
[ 2021-09-13 22:30:14 ] 50000 transcripts processed.
[ 2021-09-13 22:31:44 ] 55000 transcripts processed.
[ 2021-09-13 22:32:29 ] 60000 transcripts processed.
[ 2021-09-13 22:34:04 ] 65000 transcripts processed.
[ 2021-09-13 22:34:25 ] [ !!! moPepGen WARNING !!! ] This seqname is not found from the reference genome: CHR_HG76_PATCH Make sure your GTF and FASTA files match.
[ 2021-09-13 22:34:25 ] 70000 transcripts processed.
[ 2021-09-13 22:36:22 ] Noncanonical peptide FASTA file written to disk.
```

Closes #109 