### PR TITLE
Fixed parseVEP to handle deletion when allele is not '-'

### DIFF
--- a/moPepGen/parser/VEPParser.py
+++ b/moPepGen/parser/VEPParser.py
@@ -174,7 +174,9 @@ class VEPRecord():
                 allele = str(Seq(allele).reverse_complement())
             if alt_end - alt_start == 1:
                 if len(allele) > 1:
-                    raise ValueError('Could not recognize the VEP record')
+                    raise ValueError(
+                        f'Could not recognize the VEP record. Transcript: [{self.feature}]'
+                    )
                 ref = str(seq.seq[alt_start])
                 alt = allele
             elif alt_end - alt_start == 2:
@@ -182,7 +184,12 @@ class VEPRecord():
                 ref = str(seq.seq[alt_start])
                 alt = ref + allele
             else:
-                raise ValueError('Could not recognize the VEP record')
+                if len(allele) > 1:
+                    raise ValueError(
+                        f'Could not recognize the VEP record. Transcript: [{self.feature}]'
+                    )
+                ref = str(seq.seq[alt_start:alt_end])
+                alt = allele
 
         _type = 'SNV' if len(ref) == 1 and len(alt) == 1 else 'INDEL'
         _id = f'{_type}-{alt_start + 1}-{ref}-{alt}'

--- a/test/unit/test_vep.py
+++ b/test/unit/test_vep.py
@@ -454,5 +454,30 @@ class TestVEPRecord(unittest.TestCase):
         with self.assertRaises(TranscriptionStartSiteMutationError):
             vep_record.convert_to_variant_record(anno, genome)
 
+    def test_vep_to_variant_record_case15_deletion(self):
+        """ deletion that allele is not - """
+        genome = create_dna_record_dict(GENOME_DATA)
+        anno = create_genomic_annotation(ANNOTATION_DATA)
+
+        vep_record = VEPParser.VEPRecord(
+            uploaded_variation='rs55971985',
+            location='chr1:19-22',
+            allele='T',
+            gene='ENSG0001',
+            feature='ENST0001.1',
+            feature_type='Transcript',
+            consequences=['missense_variant'],
+            cdna_position='11',
+            cds_position='11',
+            protein_position=3,
+            amino_acids=('S', 'T'),
+            codons=('aTa', 'aCa'),
+            existing_variation='-',
+            extra={}
+        )
+        record = vep_record.convert_to_variant_record(anno, genome)
+        self.assertEqual(record.ref, 'CTAT')
+        self.assertEqual(record.alt, 'T')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In VEP's output, for most deletions, the allele are '-' (e.g. CTCCAGC/-), but not in some rare cases (e.g. CTCCAGCT/T). It is now fixed.

A unit test added.

Closes #117 