### PR TITLE
Fix bug when no ORF found in noncoding transcript

### DIFF
--- a/moPepGen/svgraph/PeptideVariantGraph.py
+++ b/moPepGen/svgraph/PeptideVariantGraph.py
@@ -494,6 +494,9 @@ class PeptideVariantGraph():
                     queue.appendleft(out_node)
                 continue
 
+            if cur is self.stop:
+                continue
+
             # skip the node if already visited
             visited_len_before = len(visited)
             visited.add(cur)

--- a/test/unit/test_peptide_variant_graph.py
+++ b/test/unit/test_peptide_variant_graph.py
@@ -357,3 +357,11 @@ class TestPeptideVariantGraph(unittest.TestCase):
         peptides = graph.call_variant_peptides(1)
         for peptide in peptides:
             self.assertTrue(peptide.description.startswith(graph.id))
+
+    def test_call_peptides_empty_graph(self):
+        """ When the graph is empty """
+        data = {}
+        graph, _ = create_pgraph(data, 'ENST0001')
+        graph.add_stop(graph.root)
+        peptides = graph.call_variant_peptides(2)
+        self.assertEqual(len(peptides), 0)


### PR DESCRIPTION
The bug #120 is because no ORF is found in the noncoding transcript, and the `call_variant_peptide` function was not handling it well. This has been fixed, and a unit test added for this situation.

Closes #120 