### PR TITLE
Skip circRNA/ciRNAs with unknown exon/intron

### DIFF
--- a/moPepGen/SeqFeature.py
+++ b/moPepGen/SeqFeature.py
@@ -46,6 +46,10 @@ class FeatureLocation(BioFeatureLocation):
         """ less or equal to """
         return not self > other
 
+    def __str__(self) -> str:
+        """ str """
+        return f"{self.seqname}:{int(self.start)}-{int(self.end)}"
+
     def __hash__(self):
         """ hash """
         return hash((self.seqname, self.start, self.end, self.strand))

--- a/moPepGen/err.py
+++ b/moPepGen/err.py
@@ -1,5 +1,11 @@
 """ Module for errors """
+from __future__ import annotations
+from typing import TYPE_CHECKING
 from moPepGen import logger
+
+
+if TYPE_CHECKING:
+    from moPepGen.gtf.GTFSeqFeature import GTFSeqFeature
 
 class VariantSourceNotFoundError(Exception):
     """ Error to be raised when the variant source of a peptide is not found """
@@ -36,7 +42,15 @@ class TranscriptionStartSiteMutationError(Exception):
         if transcript_id:
             message += f"transcript [{transcript_id}] "
         super().__init__(message)
-class ReferenceSeqnameNotFoundError(Exception):
+
+class MuteableErrorMixin():
+    """ Mixin for muteable errors """
+    @classmethod
+    def mute(cls):
+        """ Mute it """
+        cls.raised = True
+
+class ReferenceSeqnameNotFoundError(MuteableErrorMixin, Exception):
     """ Error to be raised when the seqname is not found from the reference
     genome """
     raised = False
@@ -45,10 +59,21 @@ class ReferenceSeqnameNotFoundError(Exception):
         msg = f"This seqname is not found from the reference genome: {seqname}"
         super().__init__(msg)
 
-    @classmethod
-    def mute(cls):
-        """ Mute it """
-        cls.raised = True
+class ExonNotFoundError(Exception):
+    """ Error to be raised when an exon is not found """
+    def __init__(self, gene_id:str, feature:GTFSeqFeature):
+        """ constructor """
+        msg = f"The feature {str(feature.location)} is not a valid exon from"+\
+        f" gene {gene_id}"
+        super().__init__(msg)
+
+class IntronNotFoundError(Exception):
+    """ Error to be raised when an exon is not found """
+    def __init__(self, gene_id:str, feature:GTFSeqFeature):
+        """ constructor """
+        msg = f"The feature {str(feature.location)} is not a valid intron" +\
+            f"from gene {gene_id}"
+        super().__init__(msg)
 
 def warning(msg:str) -> None:
     """ print a warning message """

--- a/moPepGen/parser/CIRCexplorerParser.py
+++ b/moPepGen/parser/CIRCexplorerParser.py
@@ -83,17 +83,18 @@ class CIRCexplorerKnownRecord():
         else:
             raise ValueError(f'circRNA type unsupported: {self.circ_type}')
 
-        circ_id += f'-{gene_id}'
+        fragment_ids = []
 
         for i, exon_size in enumerate(self.exon_sizes):
             exon_offset = self.exon_offsets[i]
             start = anno.coordinate_genomic_to_gene(
                 self.start + exon_offset, gene_id)
             end = anno.coordinate_genomic_to_gene(
-                self.start + exon_offset + exon_size, gene_id)
+                self.start + exon_offset + exon_size - 1, gene_id)
 
             if gene_model.strand == -1:
                 start, end = end, start
+            end += 1
 
             location = FeatureLocation(seqname=gene_id, start=start, end=end)
 
@@ -104,14 +105,17 @@ class CIRCexplorerKnownRecord():
 
             if fragment_type == 'exon':
                 exon_index = anno.find_exon_index(gene_id, fragment)
-                circ_id += f"-E{exon_index + 1}"
+                fragment_ids.append( f"E{exon_index + 1}")
 
             elif fragment_type == 'intron':
                 intron_index = anno.find_intron_index(gene_id, fragment)
-                circ_id += f"-I{intron_index + 1}"
+                fragment_ids.append(f"I{intron_index + 1}")
                 intron.append(i)
 
             fragments.append(fragment)
+
+        fragment_ids.sort()
+        circ_id += f'-{gene_id}-' + '-'.join(fragment_ids)
 
         return CircRNAModel(gene_id, fragments, intron, circ_id,
             transcript_ids, gene_model.gene_name)

--- a/test/unit/test_gtf.py
+++ b/test/unit/test_gtf.py
@@ -6,7 +6,7 @@ import unittest
 from test.unit import create_transcript_model, create_variant, \
     create_genomic_annotation
 from Bio import SeqIO
-from moPepGen import gtf
+from moPepGen import gtf, err
 from moPepGen.SeqFeature import FeatureLocation
 from moPepGen.gtf.GTFSeqFeature import GTFSeqFeature
 from .test_vep_parser import ANNOTATION_DATA
@@ -273,7 +273,7 @@ class TestGTF(unittest.TestCase):
         self.assertEqual(ind, 1)
 
         exon = exon2._shift(10)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(err.ExonNotFoundError):
             anno.find_exon_index(gene_id, exon, 'gene')
 
     def test_find_exon_index_case2(self):
@@ -298,7 +298,7 @@ class TestGTF(unittest.TestCase):
         self.assertEqual(ind, 2)
 
         exon = exon2._shift(10)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(err.ExonNotFoundError):
             anno.find_exon_index(gene_id, exon, 'gene')
 
     def test_find_intron_index_case1(self):
@@ -320,7 +320,7 @@ class TestGTF(unittest.TestCase):
         self.assertEqual(ind, 0)
 
         intron = intron2._shift(10)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(err.ExonNotFoundError):
             anno.find_exon_index(gene_id, intron, 'gene')
 
     def test_find_intron_index_case2(self):
@@ -348,7 +348,7 @@ class TestGTF(unittest.TestCase):
         self.assertEqual(ind, 1)
 
         intron = intron2._shift(10)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(err.ExonNotFoundError):
             anno.find_exon_index(gene_id, intron, 'gene')
 
     def test_coordinate_convert(self):


### PR DESCRIPTION
As discussed in #121 , for circRNA/ciRNAs with unknown exon/intron from the reference GTF, skip them and print warning messages.

Closes #121 