### PR TITLE
Fixing variant peptide calling issue when finding closest ORF

### DIFF
--- a/moPepGen/svgraph/PVGNode.py
+++ b/moPepGen/svgraph/PVGNode.py
@@ -180,7 +180,7 @@ class PVGNode():
 
         return sorted(self.in_nodes, key=cmp_to_key(sort_func))[0]
 
-    def find_least_Variant_next(self) -> PVGNode:
+    def find_least_variant_next(self) -> PVGNode:
         """ Find the outbond node that has the least number of variants """
         if not self.out_nodes:
             return None
@@ -393,7 +393,7 @@ class PVGNode():
                 if loc.query.start <= i < loc.query.end:
                     return (i - loc.query.start + loc.ref.start) * 3 + k
 
-        out_node = self.find_least_Variant_next()
+        out_node = self.find_least_variant_next()
         if str(out_node.seq.seq) == '*' and not out_node.out_nodes:
             return -1
         if out_node.seq.locations:

--- a/test/unit/test_peptide_variant_graph.py
+++ b/test/unit/test_peptide_variant_graph.py
@@ -129,7 +129,7 @@ class TestPeptideVariantGraph(unittest.TestCase):
             1: ('MSSSR', [0], [None], locations1, 0),
             2: ('GSSR', [1],[variant_1], [], 0),
             3: ('GSSSK', [1], [None], locations1, 0),
-            3: ('SSSG', [2], [variant_2], locations2, 0)
+            4: ('SSSG', [2], [variant_2], locations2, 0)
         }
         _,nodes = create_pgraph(data, '')
         self.assertEqual(nodes[2].get_orf_start(), 15)


### PR DESCRIPTION
The two issues reported in #145 and #146 are both happened when trying to infer the ORF start position. Currently for start gain mutations, we find the closest downstream reference sequence to use that as the ORF start. #145 is when there is a stop gain right after, so I just return -1 because this ORF isn't on reference at all. While #146 is some how two variant nodes are connected to each other exclusively. Then I now look for the least variant node instead. This won't affect anything else because we are just getting the ORF position.

Closes #145 
Closes #146 