### PR TITLE
Allow fuzzy match for introns

### DIFF
--- a/moPepGen/cli/common.py
+++ b/moPepGen/cli/common.py
@@ -229,3 +229,10 @@ def load_inclusion_exclusion_biotypes(args:argparse.Namespace
                 exclusion_biotypes.append(line.rstrip())
 
     return inclusion_biotypes, exclusion_biotypes
+
+def parse_range(x:str) -> Tuple[int,int]:
+    """ parse range from argument """
+    y = x.split(',')
+    if len(y) != 2:
+        raise ValueError('Range invalid')
+    return tuple(int(i) for i in y)

--- a/moPepGen/cli/parse_circexplorer.py
+++ b/moPepGen/cli/parse_circexplorer.py
@@ -7,7 +7,7 @@ from moPepGen import logger, circ, err
 from moPepGen.parser import CIRCexplorerParser
 from moPepGen.cli.common import add_args_reference, add_args_verbose, add_args_source,\
     print_start_message,print_help_if_missing_args, load_references, \
-    generate_metadata
+    generate_metadata, parse_range
 
 
 # pylint: disable=W0212
@@ -60,6 +60,20 @@ def add_subparser_parse_circexplorer(subparsers:argparse._SubParsersAction):
         default=None,
         metavar=''
     )
+    p.add_argument(
+        '--intron-start-range',
+        type=str,
+        help='The range of difference allowed between the intron start and'
+        ' the reference position. Defaults to -2,0',
+        default='-2,0'
+    )
+    p.add_argument(
+        '--intron-end-range',
+        type=str,
+        help='The range of difference allowed between the intron end and'
+        ' the reference position. Defaults to -100,2',
+        default='-100,2'
+    )
     add_args_source(p)
     add_args_reference(p, genome=False, proteome=False)
     add_args_verbose(p)
@@ -71,6 +85,9 @@ def parse_circexplorer(args:argparse.Namespace):
     input_path = args.input_path
     output_prefix = args.output_prefix
     output_path = output_prefix + '.gvf'
+
+    intron_start_range = parse_range(args.intron_start_range)
+    intron_end_range = parse_range(args.intron_end_range)
 
     print_start_message(args)
 
@@ -86,7 +103,8 @@ def parse_circexplorer(args:argparse.Namespace):
                 args.min_circ_score):
             continue
         try:
-            circ_record = record.convert_to_circ_rna(anno)
+            circ_record = record.convert_to_circ_rna(anno, intron_start_range,
+                intron_end_range)
         except err.ExonNotFoundError:
             err.warning(f"The CIRCexplorer record {record.name} from"
                 f" transcript {record.isoform_name} contains an unknown exon."

--- a/moPepGen/parser/CIRCexplorerParser.py
+++ b/moPepGen/parser/CIRCexplorerParser.py
@@ -36,8 +36,9 @@ class CIRCexplorer2KnownRecord():
         self.index = index
         self.flank_intron = flank_intron
 
-    def convert_to_circ_rna(self, anno:gtf.GenomicAnnotation
-            ) -> CircRNAModel:
+    def convert_to_circ_rna(self, anno:gtf.GenomicAnnotation,
+            intron_start_range:Tuple[int,int]=(0,0),
+            intron_end_range:Tuple[int,int]=(0,0)) -> CircRNAModel:
         """ COnvert a CIRCexplorerKnownRecord to CircRNAModel. """
         tx_id = self.isoform_name
         tx_model = anno.transcripts[tx_id]
@@ -81,8 +82,11 @@ class CIRCexplorer2KnownRecord():
                 fragment_ids.append( f"E{exon_index + 1}")
 
             elif fragment_type == 'intron':
-                intron_index = anno.find_intron_index(tx_id, fragment,
-                    exact_end=False)
+                intron_index = anno.find_intron_index(
+                    tx_id, fragment,
+                    intron_start_range=intron_start_range,
+                    intron_end_range=intron_end_range
+                )
                 fragment_ids.append(f"I{intron_index + 1}")
                 intron.append(i)
 

--- a/test/integration/test_parse_circexplorer.py
+++ b/test/integration/test_parse_circexplorer.py
@@ -19,6 +19,8 @@ class TestParseCIRCexplorer(TestCaseIntegration):
         args.proteome_fasta = self.data_dir/'translate.fasta'
         args.circexplorer3 = False
         args.min_read_number = 1
+        args.intron_start_range = '-2,0'
+        args.intron_end_range = '-100,2'
         args.verbose = False
         cli.parse_circexplorer(args)
         files = {str(file.name) for file in self.work_dir.glob('*')}
@@ -40,6 +42,8 @@ class TestParseCIRCexplorer(TestCaseIntegration):
         args.min_read_number = 1
         args.min_fbr_circ = None
         args.min_circ_score = None
+        args.intron_start_range = '-2,0'
+        args.intron_end_range = '-100,2'
         args.verbose = False
         cli.parse_circexplorer(args)
         files = {str(file.name) for file in self.work_dir.glob('*')}

--- a/test/unit/test_gtf.py
+++ b/test/unit/test_gtf.py
@@ -353,6 +353,42 @@ class TestGTF(unittest.TestCase):
         with self.assertRaises(err.ExonNotFoundError):
             anno.find_exon_index(tx_id, intron, 'gene')
 
+    def test_find_intron_index_fuzzy_1(self):
+        """ Test finding intron index with end is earlier """
+        anno = create_genomic_annotation(ANNOTATION_DATA)
+        gene_id = 'ENSG0001'
+        tx_id = 'ENST0001.1'
+        start = anno.transcripts[tx_id].exon[0].location.end
+        end = anno.transcripts[tx_id].exon[1].location.start - 2
+        strand = anno.genes[gene_id].location.strand
+        location = FeatureLocation(seqname=gene_id, start=start, end=end,
+            strand=strand)
+        intron = GTFSeqFeature(chrom=gene_id, location=location, attributes={})
+        ind = anno.find_intron_index(tx_id, intron, 'genomic',
+            intron_end_range=(-3, 0))
+        self.assertEqual(ind, 0)
+
+    def test_find_intron_index_fuzzy_2(self):
+        """ Test finding intron index with star is earlier in - strand """
+        anno = create_genomic_annotation(ANNOTATION_DATA)
+        for gene in anno.genes.values():
+            gene.location.strand = -1
+        for transcript in anno.transcripts.values():
+            transcript.transcript.location.strand = -1
+            for exon in transcript.exon:
+                exon.location.strand = -1
+        gene_id = 'ENSG0001'
+        tx_id = 'ENST0001.1'
+        start = anno.transcripts[tx_id].exon[0].location.end
+        end = anno.transcripts[tx_id].exon[1].location.start + 1
+        strand = anno.genes[gene_id].location.strand
+        location = FeatureLocation(seqname=gene_id, start=start, end=end,
+            strand=strand)
+        intron = GTFSeqFeature(chrom=gene_id, location=location, attributes={})
+        ind = anno.find_intron_index(tx_id, intron, 'genomic',
+            intron_start_range=(-2, 0))
+        self.assertEqual(ind, 1)
+
     def test_coordinate_convert(self):
         """ Convert coodinates """
         anno = create_genomic_annotation(ANNOTATION_DATA)


### PR DESCRIPTION
As discussed in #162, now we allow intron start and end to mismatch with the reference positions within a given range. The default is -2 to 0 for start and and -100 to 2 for end. 

Closes #162 