### PR TITLE
Adding dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+test/files
+.git
+.vscode
+.github
+.ipynb_checkpoint
+.pytest_cache
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM blcdsdockerregistry/bl-base:1.0.0 AS builder
+
+COPY . /opt/moPepGen
+
+ARG PYTHON_VER=3.8.11
+
+RUN conda create -qy -p /usr/local\
+    python==${PYTHON_VER}
+
+RUN cd /opt/moPepGen/ && \
+    pip install . --use-feature=in-tree-build
+
+# Deploy the target tools into a base image
+FROM ubuntu:20.04
+COPY --from=builder /usr/local /usr/local
+
+LABEL maintainer="Chenghao Zhu <ChenghaoZhu@mednet.ucla.edu>"


### PR DESCRIPTION
Adding a dockerfile to the repo. In the future, every push or PR merge to the main branch will trigger docker hub to build the image at tag 'dev'. The docker hub repo is [blcdsdockerregistry/mopepgen](https://hub.docker.com/repository/docker/blcdsdockerregistry/mopepgen). In the future, we can set up rules to get docker hub build images on releases.