### PR TITLE
fix (parseCIRCexplorer): default intron_end_range

### DIFF
--- a/moPepGen/cli/parse_circexplorer.py
+++ b/moPepGen/cli/parse_circexplorer.py
@@ -72,7 +72,7 @@ def add_subparser_parse_circexplorer(subparsers:argparse._SubParsersAction):
         type=str,
         help='The range of difference allowed between the intron end and'
         ' the reference position. Defaults to -100,2',
-        default='-100,2'
+        default='-100,5'
     )
     add_args_source(p)
     add_args_reference(p, genome=False, proteome=False)


### PR DESCRIPTION
Change `--intron-end-range` default to '-100,5'

Closes #169 