### PR TITLE
Adding a module to validate call variant results

### DIFF
--- a/test/downsample_reference.py
+++ b/test/downsample_reference.py
@@ -244,9 +244,8 @@ def shift_reference(gene_seqs:dna.DNASeqDict, anno:gtf.GenomicAnnotation
                 shift_seq_feature(cds, shift_offset, seqname)
     return genome, anno
 
-def main():
+def main(args):
     """ Downsample reference FASTA and GTF """
-    args = parse_args()
     genome_fasta:Path = args.genome_fasta
     annotation_gtf:Path = args.annotation_gtf
     protein_fasta:Path = args.protein_fasta
@@ -273,4 +272,5 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _args = parse_args()
+    main(_args)

--- a/test/validate_call_variant.py
+++ b/test/validate_call_variant.py
@@ -1,0 +1,156 @@
+""" Validate callVariant result with bruteForce """
+import argparse
+from contextlib import redirect_stdout
+from pathlib import Path
+from test.downsample_reference import main as downsample_reference
+from test.call_variant_peptide_brute_force import main as brute_force
+from Bio import SeqIO
+from moPepGen.cli.common import add_args_reference
+from moPepGen.cli import call_variant_peptide
+from moPepGen import logger
+
+
+def parse_args():
+    """ parse args """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-i', '--input-gvf',
+        type=Path,
+        help='Input GVF file.'
+    )
+    parser.add_argument(
+        '-t', '--tx-id',
+        type=str,
+        help='Transcript ID'
+    )
+    parser.add_argument(
+        '-o', '--output-dir',
+        type=Path,
+        help='Output dir'
+    )
+    add_args_reference(parser, proteome=True, index=False)
+    return parser.parse_args()
+
+def call_downsample_reference(genome:Path, anno:Path, protein:Path, tx_id:str,
+        output_dir:Path):
+    """ downsample reference """
+    args = argparse.Namespace()
+    args.genome_fasta = genome
+    args.annotation_gtf = anno
+    args.protein_fasta = protein
+    args.tx_list = [tx_id]
+    args.gene_list = None
+    args.output_dir = output_dir
+    args.miscleavage = 2
+    args.min_mw = 500.
+    downsample_reference(args)
+
+def extract_gvf(tx_id:str, gvf_file:Path, output_path:Path):
+    """ extract GVF """
+    i = 0
+    with open(gvf_file, 'rt') as in_handle, open(output_path, 'wt') as out_handle:
+        for line in in_handle:
+            if line.startswith('#'):
+                out_handle.write(line)
+            elif tx_id in line:
+                out_handle.write(line)
+                i += 0
+    if i > 10:
+        logger(f"{i} variants found. The brute force caller is going to take a while.")
+
+def call_variant(gvf_file:Path, ref_dir:Path, output_fasta:Path):
+    """ call variant """
+    args = argparse.Namespace()
+    args.index_dir = None
+    args.command = 'callPeptides'
+    args.input_variant = [gvf_file]
+    args.genome_fasta = ref_dir/'genome.fasta'
+    args.annotation_gtf = ref_dir/'annotation.gtf'
+    args.proteome_fasta = ref_dir/'proteome.fasta'
+    args.circ_rna_bed = None
+    args.output_fasta = output_fasta
+    args.verbose = True
+    args.cleavage_rule = 'trypsin'
+    args.miscleavage = 2
+    args.min_mw = 500.
+    args.min_length = 7
+    args.max_length = 25
+    args.max_frameshift_dist = 75
+    args.max_frameshift_num = 3
+    call_variant_peptide(args=args)
+
+def call_brute_force(gvf_file:Path, ref_dir:Path, output_path):
+    """ call brute force """
+    args = argparse.Namespace()
+    args.input_gvf = gvf_file
+    args.reference_dir = ref_dir
+    args.cleavage_rule = 'trypsin'
+    args.miscleavage = 2
+    args.min_mw = 500
+
+    with open(output_path, 'wt') as handle:
+        with redirect_stdout(handle):
+            brute_force(args)
+
+def assert_equal(variant_fasta:Path, brute_force_txt:Path):
+    """ assert equal """
+    with open(variant_fasta, 'rt') as handle:
+        variant_seqs = set()
+        for seq in SeqIO.parse(handle, 'fasta'):
+            variant_seqs.add(str(seq.seq))
+    with open(brute_force_txt, 'rt') as handle:
+        brute_force_seqs = set()
+        for line in handle:
+            brute_force_seqs.add(line.rstrip())
+
+    if variant_seqs != brute_force_seqs:
+        logger('Not equal!')
+    else:
+        logger('Equal!')
+
+def main(args:argparse.Namespace):
+    """ main entrypoint """
+    output_dir:Path = args.output_dir
+    ref_dir = output_dir/'index'
+    call_downsample_reference(
+        genome=args.genome_fasta,
+        anno=args.annotation_gtf,
+        protein=args.proteome_fasta,
+        tx_id=args.tx_id,
+        output_dir=ref_dir
+    )
+
+    logger('Reference files downsampling completed.')
+
+    temp_gvf = output_dir/f"{args.tx_id}.gvf"
+    extract_gvf(
+        tx_id=args.tx_id,
+        gvf_file=args.input_gvf,
+        output_path=temp_gvf
+    )
+
+    logger('Transcript variants extracted from GVF.')
+
+    variant_fasta = output_dir/'call_variant.fasta'
+    call_variant(
+        gvf_file=temp_gvf,
+        ref_dir=ref_dir,
+        output_fasta=variant_fasta
+    )
+
+    logger('Variant peptide calling completed.')
+
+    brute_force_txt = output_dir/'brute_force.txt'
+    call_brute_force(
+        gvf_file=temp_gvf,
+        ref_dir=ref_dir,
+        output_path=brute_force_txt
+    )
+
+    logger('Brute force completed.')
+
+    assert_equal(variant_fasta, brute_force_txt)
+
+if __name__ == '__main__':
+    _args = parse_args()
+    main(_args)


### PR DESCRIPTION
This script does what it says in the title. It first downsamples the reference genome, gtf, and protein sequences to contain just the specified transcript, and then downsamples the GVF file also to only contain this transcript, and calls the `moPepGen callVariant` and the brute force caller separately, compares the results in the end.

We probably should organize all the helper scripts into another module. Right now they are all under test.

Usage:

```bash
python -m test.validate_call_variant \
    -i /hot/users/yiyangliu/MoPepGen/Parser/VEP/gencode.aa/gindel/CPCG0102.gencode.aa.tsv.gvf \
    -t ENST00000245983.6 \
    -g /hot/ref/reference/GRCh38-EBI-GENCODE34/GRCh38.p13.genome.fa \
    -a /hot/ref/reference/GRCh38-EBI-GENCODE34/gencode.v34.chr_patch_hapl_scaff.annotation.gtf \
    -p /hot/ref/reference/GRCh38-EBI-GENCODE34/gencode.v34.pc_translations.fa \
    -o test/files/tmp
```

Output:

```
[ 2021-10-28 23:19:21 ] Reference files downsampling completed.
[ 2021-10-28 23:19:21 ] Transcript variants extracted from GVF.
[ 2021-10-28 23:19:21 ] moPepGen callPeptides started
[ 2021-10-28 23:19:21 ] Annotation GTF loaded.
[ 2021-10-28 23:19:21 ] Genome assembly FASTA loaded.
[ 2021-10-28 23:19:21 ] Proteome FASTA loaded.
[ 2021-10-28 23:19:21 ] canonical peptide pool generated.
[ 2021-10-28 23:19:21 ] Variant file test/files/tmp/ENST00000245983.6.gvf loaded.
[ 2021-10-28 23:19:21 ] Variant records sorted.
[ 2021-10-28 23:19:21 ] Variant peptide FASTA file written to disk.
[ 2021-10-28 23:19:21 ] Variant peptide calling completed.
/hot/users/czhu/conda/envs/python3.8/lib/python3.8/site-packages/Bio/Seq.py:2979: BiopythonWarning: Partial codon, len(sequence) not a multiple of three. Explicitly trim the sequence or add trailing N before translation. This may become an error in future.
  warnings.warn(
[ 2021-10-28 23:19:21 ] Brute force completed.
[ 2021-10-28 23:19:21 ] Equal!
```