### PR TITLE
fix (parseRMATS): insertion position fixed

### DIFF
--- a/moPepGen/parser/RMATSParser/A3SSRecord.py
+++ b/moPepGen/parser/RMATSParser/A3SSRecord.py
@@ -87,9 +87,9 @@ class A3SSRecord(RMATSRecord):
             genomic_position = f'{chrom}:{self.short_exon_end}-{self.long_exon_end}'
 
         if not short:
+            location = FeatureLocation(seqname=self.gene_id, start=start_gene,
+                end=end_gene)
             for tx_id in long:
-                location = FeatureLocation(seqname=self.gene_id,
-                    start=start_gene, end=end_gene)
                 ref = str(gene_seq.seq[start_gene])
                 alt = '<DEL>'
                 attrs = {
@@ -105,13 +105,19 @@ class A3SSRecord(RMATSRecord):
                 variants.append(record)
 
         if not long:
-            for tx_id in short:
-                insert_position = start_gene
-                location = FeatureLocation(
-                    seqname=self.gene_id,
-                    start=insert_position,
-                    end=insert_position + 1
+            if gene_model.strand == 1:
+                insert_position = anno.coordinate_genomic_to_gene(
+                    index=self.flanking_exon_end - 1,
+                    gene=self.gene_id
                 )
+            else:
+                insert_position = anno.coordinate_genomic_to_gene(
+                    index=self.flanking_exon_start,
+                    gene=self.gene_id
+                )
+            location = FeatureLocation(seqname=self.gene_id, start=insert_position,
+                end=insert_position + 1)
+            for tx_id in short:
                 ref = str(gene_seq.seq[insert_position])
                 alt = '<INS>'
                 attrs = {

--- a/moPepGen/parser/RMATSParser/A5SSRecord.py
+++ b/moPepGen/parser/RMATSParser/A5SSRecord.py
@@ -87,9 +87,9 @@ class A5SSRecord(RMATSRecord):
             genomic_position = f'{chrom}:{self.long_exon_start+1}-{self.short_exon_end}'
 
         if not short:
+            location = FeatureLocation(seqname=self.gene_id, start=start_gene,
+                end=end_gene)
             for tx_id in long:
-                location = FeatureLocation(seqname=self.gene_id, start=start_gene,
-                    end=end_gene)
                 ref = str(gene_seq.seq[start_gene])
                 alt = '<DEL>'
                 attrs = {
@@ -105,13 +105,10 @@ class A5SSRecord(RMATSRecord):
                 variants.append(record)
 
         if not long:
-            insert_position = start_gene
+            insert_position = start_gene - 1
+            location = FeatureLocation(seqname=self.gene_id, start=insert_position,
+                end=insert_position + 1)
             for tx_id in short:
-                location = FeatureLocation(
-                    seqname=self.gene_id,
-                    start=insert_position,
-                    end=insert_position+1
-                )
                 ref = str(gene_seq.seq[insert_position])
                 alt = '<INS>'
                 attrs = {

--- a/moPepGen/parser/RMATSParser/MXERecord.py
+++ b/moPepGen/parser/RMATSParser/MXERecord.py
@@ -128,9 +128,9 @@ class MXERecord(RMATSRecord):
             f'{second_start}-{second_end}'
 
         if not have_second:
+            location = FeatureLocation(seqname=self.gene_id, start=first_start,
+                end=first_end)
             for tx_id in have_first:
-                location = FeatureLocation(seqname=self.gene_id, start=first_start,
-                    end=first_end)
                 ref = str(gene_seq.seq[first_start])
                 alt = '<SUB>'
                 attrs = {
@@ -149,9 +149,9 @@ class MXERecord(RMATSRecord):
                 record = seqvar.VariantRecord(location, ref, alt, _type, _id, attrs)
                 variants.append(record)
 
-            for tx_id in have_both:
-                location = FeatureLocation(seqname=self.gene_id, start=first_start,
+            location = FeatureLocation(seqname=self.gene_id, start=first_start,
                     end=first_end)
+            for tx_id in have_both:
                 ref = str(gene_seq.seq[first_start])
                 alt = '<DEL>'
                 attrs = {
@@ -166,9 +166,9 @@ class MXERecord(RMATSRecord):
                 variants.append(record)
 
         if not have_first:
+            location = FeatureLocation(seqname=self.gene_id, start=second_start,
+                end=second_end)
             for tx_id in have_second:
-                location = FeatureLocation(seqname=self.gene_id, start=second_start,
-                    end=second_end)
                 ref = str(gene_seq.seq[second_start])
                 alt = '<SUB>'
                 attrs = {
@@ -186,9 +186,9 @@ class MXERecord(RMATSRecord):
                 record = seqvar.VariantRecord(location, ref, alt, _type, _id, attrs)
                 variants.append(record)
 
+            location = FeatureLocation(seqname=self.gene_id, start=second_start,
+                end=second_end)
             for tx_id in have_both:
-                location = FeatureLocation(seqname=self.gene_id, start=second_start,
-                    end=second_end)
                 ref = str(gene_seq.seq[second_start])
                 alt = '<DEL>'
                 attrs = {

--- a/moPepGen/parser/RMATSParser/RIRecord.py
+++ b/moPepGen/parser/RMATSParser/RIRecord.py
@@ -75,14 +75,16 @@ class RIRecord(RMATSRecord):
 
         genomic_position = f'{chrom}:{self.upstream_exon_end}-{self.downstream_exon_start}'
 
+        insert_position = start_gene - 1
+        location = FeatureLocation(seqname=self.gene_id, start=insert_position,
+            end=insert_position + 1)
+
         for tx_id in have_adjacent:
-            location = FeatureLocation(seqname=self.gene_id, start=start_gene - 1,
-                end=start_gene)
-            ref = str(gene_seq.seq[start_gene])
+            ref = str(gene_seq.seq[insert_position])
             alt = '<INS>'
             attrs = {
                 'TRANSCRIPT_ID': tx_id,
-                'DONOR_START': start_gene - 1,
+                'DONOR_START': start_gene,
                 'DONOR_END': end_gene,
                 'DONOR_GENE_ID': self.gene_id,
                 'COORDINATE': 'gene',

--- a/moPepGen/parser/RMATSParser/SERecord.py
+++ b/moPepGen/parser/RMATSParser/SERecord.py
@@ -84,12 +84,12 @@ class SERecord(RMATSRecord):
         if gene_model.strand == -1:
             start, end = end, start
         end += 1
-        location = FeatureLocation(seqname=self.gene_id, start=start, end=end)
         ref = str(gene_seq.seq[start])
 
         genomic_position = f'{chrom}:{self.exon_start+1}:{self.exon_end}'
 
         if not skipped:
+            location = FeatureLocation(seqname=self.gene_id, start=start, end=end)
             for tx_id in retained:
                 alt = '<DEL>'
                 attrs = {
@@ -105,20 +105,19 @@ class SERecord(RMATSRecord):
                 variants.append(record)
 
         if not retained:
-            if gene_model.location.strand == 1:
+            if gene_model.strand == 1:
                 insert_position = anno.coordinate_genomic_to_gene(
-                    self.upstream_exon_end, self.gene_id
+                    index=self.upstream_exon_end - 1,
+                    gene=self.gene_id
                 )
             else:
                 insert_position = anno.coordinate_genomic_to_gene(
-                    self.downstream_exon_start, self.gene_id
+                    index=self.downstream_exon_start,
+                    gene=self.gene_id
                 )
+            location = FeatureLocation(seqname=self.gene_id, start=insert_position,
+                end=insert_position + 1)
             for tx_id in skipped:
-                location = FeatureLocation(
-                    seqname=tx_id,
-                    start=insert_position,
-                    end=insert_position + 1
-                )
                 ref = str(gene_seq.seq[insert_position])
                 alt = '<INS>'
                 attrs = {

--- a/moPepGen/util/downsample_reference.py
+++ b/moPepGen/util/downsample_reference.py
@@ -217,7 +217,7 @@ def downsample_reference(args:argparse.Namespace):
     """ Downsample reference FASTA and GTF """
     genome_fasta:Path = args.genome_fasta
     annotation_gtf:Path = args.annotation_gtf
-    protein_fasta:Path = args.protein_fasta
+    protein_fasta:Path = args.proteome_fasta
     gene_list:List[str] = args.gene_list
     tx_list:List[str] = args.tx_list
     output_dir:Path = args.output_dir


### PR DESCRIPTION
Insertion position should now be fixed. For insertion-like alternative splicing events of which the start of insertion is the start of an exon, the insertion location is then set to the last nucleotide of the last upstream exon.

Closes #188 