### PR TITLE
fixed `proteome_fasta` not defined in validateVariantCalling

### DIFF
--- a/moPepGen/util/validate_variant_calling.py
+++ b/moPepGen/util/validate_variant_calling.py
@@ -2,6 +2,7 @@
 import argparse
 from contextlib import redirect_stdout
 from pathlib import Path
+import sys
 from Bio import SeqIO
 from moPepGen.cli.common import add_args_reference, print_help_if_missing_args
 from moPepGen.cli import call_variant_peptide
@@ -98,7 +99,7 @@ def call_brute_force(gvf_file:Path, ref_dir:Path, output_path):
         with redirect_stdout(handle):
             brute_force(args)
 
-def assert_equal(variant_fasta:Path, brute_force_txt:Path):
+def assert_equal(variant_fasta:Path, brute_force_txt:Path, output_dir:Path):
     """ assert equal """
     with open(variant_fasta, 'rt') as handle:
         variant_seqs = set()
@@ -111,8 +112,20 @@ def assert_equal(variant_fasta:Path, brute_force_txt:Path):
 
     if variant_seqs != brute_force_seqs:
         logger('Not equal!')
-    else:
-        logger('Equal!')
+        variant_only = variant_seqs - brute_force_seqs
+        brute_force_only = brute_force_seqs - variant_seqs
+        if variant_only:
+            variant_only_file = output_dir/'call_variant_only.txt'
+            with open(variant_only_file, 'wt') as handle:
+                for seq in variant_only:
+                    handle.write(seq + '\n')
+        if brute_force_only:
+            brute_force_only_file = output_dir/'brute_force_only.txt'
+            with open(brute_force_only_file, 'rt') as handle:
+                for seq in brute_force_only:
+                    handle.write(seq + '\n')
+        sys.exit(1)
+    logger('Equal!')
 
 def validate_variant_calling(args:argparse.Namespace):
     """ main entrypoint """
@@ -155,4 +168,4 @@ def validate_variant_calling(args:argparse.Namespace):
 
     logger('Brute force completed.')
 
-    assert_equal(variant_fasta, brute_force_txt)
+    assert_equal(variant_fasta, brute_force_txt, output_dir)


### PR DESCRIPTION
Do you think it's helpful to compare the three-frame output and brute force output and print out the records that don't match? I can add it to this PR if you think it's a good idea.