### PR TITLE
Fix callVariant

### DIFF
--- a/moPepGen/svgraph/ThreeFrameTVG.py
+++ b/moPepGen/svgraph/ThreeFrameTVG.py
@@ -561,12 +561,12 @@ class ThreeFrameTVG():
                 break
 
             # skipping start lost mutations
-            start_index = self.seq.orf.start + 3 if self.has_known_orf else 2
+            start_index = self.seq.orf.start + 3 if self.has_known_orf else 3
 
             if variant.location.start == start_index - 1 and variant.is_insertion():
                 variant.to_end_inclusion(self.seq)
 
-            if variant.location.start <= start_index:
+            if variant.location.start < start_index:
                 variant = next(variant_iter, None)
                 continue
 


### PR DESCRIPTION
A silly mistake. In case of noncoding transcripts, the 'start position' should be 0-3 rather than 0-2. In the case reported in #236 , there is a variant that starts at the third nucleotide which should be skipped but was not and was causing this issue.

Closes #236 