### PR TITLE
Fix `create_cleavage_graph` to continue when fusion attached to the end of the transcript

### DIFF
--- a/moPepGen/svgraph/PeptideVariantGraph.py
+++ b/moPepGen/svgraph/PeptideVariantGraph.py
@@ -58,7 +58,7 @@ class PeptideVariantGraph():
 
     def next_is_stop(self, node:PVGNode) -> bool:
         """ Checks if stop is linked as a outbound node. """
-        return self.stop in node.out_nodes
+        return len(node.out_nodes) == 1 and self.stop in node.out_nodes
 
     @staticmethod
     def remove_node(node:PVGNode) -> None:

--- a/moPepGen/svgraph/ThreeFrameTVG.py
+++ b/moPepGen/svgraph/ThreeFrameTVG.py
@@ -169,7 +169,10 @@ class ThreeFrameTVG():
 
     def add_stop_node(self, node:TVGNode):
         """ Add stop node after the given node """
-        stop = TVGNode(DNASeqRecordWithCoordinates('', []))
+        stop = TVGNode(
+            DNASeqRecordWithCoordinates('', []),
+            reading_frame_index=node.reading_frame_index
+        )
         self.add_edge(node, stop, 'reference')
 
     def count_nodes(self):

--- a/moPepGen/util/downsample_reference.py
+++ b/moPepGen/util/downsample_reference.py
@@ -152,7 +152,9 @@ def get_gene_sequences(path:Path, anno:gtf.GenomicAnnotation) -> dna.DNASeqDict:
             continue
         for gene_model in chrom_genes[record.id]:
             gene_id = gene_model.gene_id
-            gene_seqs[gene_id] = gene_model.get_gene_sequence(record)
+            seq = gene_model.get_gene_sequence(record)
+            seq.__class__ = dna.DNASeqRecord
+            gene_seqs[gene_id] = seq
     return gene_seqs
 
 def downsample_proteins(path:Path, anno:gtf.GenomicAnnotation


### PR DESCRIPTION
The fix seems to be easy. Just need to make sure it is not treated as the 'end' when there is a fusion in the end the transcript

Closes #275 