### PR TITLE
fix (filterFasta): coding transcript pickle file path

### DIFF
--- a/moPepGen/cli/filter_fasta.py
+++ b/moPepGen/cli/filter_fasta.py
@@ -159,7 +159,7 @@ def load_expression_table(handle:IO, tx_col:int,quant_col:int,
 def load_coding_transcripts(args:argparse.Namespace) -> List[str]:
     """ load and get the protein coding transcripts """
     if args.index_dir:
-        with open(args.index_dir/'coding.pkl', 'rb') as handle:
+        with open(args.index_dir/'coding_transcripts.pkl', 'rb') as handle:
             return pickle.loads(handle)
 
     anno = GenomicAnnotation()


### PR DESCRIPTION
The coding transcript pickle file path was fixed. All reference file paths are hard coded for now. At some point, we should probably modularize them, for example put all reference index related logic (read and write) into a class such as `ReferenceIndex`. But for now let's just focus on making it work.

Closes #279 