### PR TITLE
fix (util): `translate_noncoding` missing in `validateVaraintCalling`

### DIFF
--- a/moPepGen/util/validate_variant_calling.py
+++ b/moPepGen/util/validate_variant_calling.py
@@ -66,6 +66,7 @@ def call_downsample_reference(genome:Path, anno:Path, protein:Path, tx_id:str,
     args.output_dir = output_dir
     args.miscleavage = 2
     args.min_mw = 500.
+    args.translate_noncoding = 'true'
     downsample_reference(args)
 
 def extract_gvf(tx_id:str, gvf_files:List[Path], output_path:Path):


### PR DESCRIPTION
I guess we really should have some unit test cases for the `util` command.

Closes #291 