### PR TITLE
`seqname` missed after Deletion is shifted up causing None in the final FASTA header

### DIFF
--- a/moPepGen/seqvar/VariantRecord.py
+++ b/moPepGen/seqvar/VariantRecord.py
@@ -449,7 +449,8 @@ class VariantRecord():
         """ shift deletion variant up exact one position """
         location = FeatureLocation(
             start=self.location.start - 1,
-            end = self.location.end
+            end=self.location.end,
+            seqname=self.location.seqname
         )
         ref = str(tx_seq.seq[location.start])
         self.location = location


### PR DESCRIPTION
A simple fix to #318

Closes #318 