### PR TITLE
Fix `callVariant` that known start codon was searched on fusion accepter sequence

### DIFF
--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -216,7 +216,7 @@ def call_variant_peptide(args:argparse.Namespace) -> None:
             if variant_series.is_empty():
                 continue
             if noncanonical_transcripts and \
-                    variant_series.has_any_noncanonical_transcripts():
+                    not variant_series.has_any_noncanonical_transcripts():
                 continue
             tx_ids += variant_series.get_additional_transcripts()
             tx_ids = list(set(tx_ids))

--- a/moPepGen/svgraph/PeptideVariantGraph.py
+++ b/moPepGen/svgraph/PeptideVariantGraph.py
@@ -743,7 +743,8 @@ class PeptideVariantGraph():
         in_cds = cursor.in_cds
         orf = cursor.orf
         start_gain = cursor.start_gain
-        if target_node.reading_frame_index != self.known_reading_frame_index():
+        if target_node.reading_frame_index != self.known_reading_frame_index() or\
+                target_node.subgraph_id != self.id:
             for out_node in target_node.out_nodes:
                 cur = PVGCursor(target_node, out_node, False, orf, [])
                 traversal.stage(target_node, out_node, cur)


### PR DESCRIPTION
The main cause of issue #319 is this. When calling variant peptides from PVG, the if the transcript is protein coding, the translation start site is known. And when walking through the graph, the node position is compared to the known start site to find the translation start site. However, in some cases, if a fusion that introduce some novel stop codon, the "looking for start codon" task will be applied to the rest of the accepter transcript, which should not happen.

I also fixed an issue that when `--noncanonical-transcript` is given, only canonical transcript was processed instead of the other way around.

This is a simple fix, and the downsampled genome is just way too large so I did not include it as a test case.

Closes #319