### PR TITLE
Fix callVariant with circRNA

### DIFF
--- a/moPepGen/seqvar/VariantRecordPool.py
+++ b/moPepGen/seqvar/VariantRecordPool.py
@@ -154,8 +154,8 @@ class VariantRecordPool():
         if segments:
             def _filter(x):
                 for segment in segments:
-                    if segment.location.is_superset(x.location) and \
-                            segment.location.end != x.location.end:
+                    if segment.location.start < x.location.start < \
+                            x.location.end < segment.location.end:
                         return True
                 return False
         elif start is not None and end is not None:


### PR DESCRIPTION
Fixed #315. The trouble was in the filtering function of variant records, which included variants that alter the last nucleotide of the circRNA sequence. Confirmed case 1 is resolved, now checking the other cases of #315

Closes #315