### PR TITLE
Update changelog version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
-## [0.2.0-rc.1] - 2021-01-27
+## [0.2.0] - 2021-01-28
 
 ### Added
 


### PR DESCRIPTION
Seems like the `__version__` is already 0.2.0. This is the last PR before 0.2.0!