### PR TITLE
Filter variants of donor transcript when call variants for fusion to keep only exonic ones

### DIFF
--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -160,11 +160,20 @@ def call_variant_peptides_wrapper(tx_id:str,
             raise
 
     peptides = set()
+    exclude_variant_types = ['Fusion', 'Insertion', 'Deletion', 'Substitution', 'circRNA']
     for variant in variant_series.fusion:
+        filtered_variants = pool.filter_variants(
+            tx_ids=[tx_id], start=0, end=variant.location.start,
+            exclude_type=exclude_variant_types, intron=False,
+            return_coord='transcript'
+        )
+        variant_pool = copy.copy(pool)
+        variant_pool[tx_id] = copy.copy(pool[tx_id])
+        variant_pool[tx_id].transcriptional = filtered_variants
         try:
             _peptides = call_peptide_fusion(
-                variant=variant, variant_pool=pool, anno=anno, genome=None,
-                tx_seqs=tx_seqs, gene_seqs=gene_seqs, rule=rule,
+                variant=variant, variant_pool=variant_pool, anno=anno,
+                genome=None, tx_seqs=tx_seqs, gene_seqs=gene_seqs, rule=rule,
                 exception=exception, miscleavage=miscleavage,
                 max_variants_per_node=max_variants_per_node
             )

--- a/moPepGen/seqvar/VariantRecordPool.py
+++ b/moPepGen/seqvar/VariantRecordPool.py
@@ -1,5 +1,6 @@
 """ Variant Record Pool """
 from __future__ import annotations
+import copy
 from typing import Dict, IO, Iterable, List, TYPE_CHECKING, Union
 from moPepGen import ERROR_INDEX_IN_INTRON
 from moPepGen.seqvar.VariantRecordPoolOnDisk import TranscriptionalVariantSeries
@@ -59,6 +60,12 @@ class VariantRecordPool():
         """ generator """
         for key in self.data:
             yield key
+
+    def __copy__(self) -> VariantRecordPool:
+        """ copy """
+        data = copy.copy(self.data)
+        anno = copy.copy(self.anno)
+        return self.__class__(data, anno)
 
     def add_intronic_variant(self, record:VariantRecord, tx_id:str=None):
         """ Add a variant with genetic coordinate that is in the intron of

--- a/moPepGen/seqvar/VariantRecordPoolOnDisk.py
+++ b/moPepGen/seqvar/VariantRecordPoolOnDisk.py
@@ -1,5 +1,6 @@
 """ Variant Record Pool """
 from __future__ import annotations
+import copy
 from typing import Dict, IO, Iterable, List, TYPE_CHECKING, Union
 from pathlib import Path
 from moPepGen import ERROR_INDEX_IN_INTRON, check_sha512
@@ -27,6 +28,15 @@ class TranscriptionalVariantSeries():
         self.intronic = intronic or []
         self.fusion = fusion or []
         self.circ_rna = circ_rna or []
+
+    def __copy__(self) -> TranscriptionalVariantSeries:
+        """ copy """
+        return self.__class__(
+            transcriptional=copy.copy(self.transcriptional),
+            intronic=copy.copy(self.intronic),
+            fusion=copy.copy(self.fusion),
+            circ_rna=copy.copy(self.circ_rna)
+        )
 
     def sort(self):
         """ Sort each slot of variants in order """


### PR DESCRIPTION
When calling for variant peptides of fusion, the variants of the donor transcript was not filtered, so it ends up with alternative splicing being kept, which caused the issue #387 . So I added an extra step to filter out those alternative splicing, additional fusion, and circRNA.

CLoses #387