### PR TITLE
Let `summarizeFasta` ignore sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fixed the problem that in `summarizeFasta` output the order of variant sources in the same group is not consistent across runs. #428
 
+- Argument `--ignore-missing-source` added to `summarizeFasta` so sources not present in any GVF can be ignored without raising any error. #436
+
 - In `filterFasta`, when filter with expression table, changed to filter out peptides smaller than, instead of smaller or equal to, the value of `--quant-cutoff`.
 
 - Fixed the issue that in `splitFasta`, variant sources are not grouped as they are specified by `--group-source` #439

--- a/moPepGen/cli/summarize_fasta.py
+++ b/moPepGen/cli/summarize_fasta.py
@@ -64,6 +64,11 @@ def add_subparser_summarize_fasta(subparser:argparse._SubParsersAction):
         metavar='<file>',
         default=None
     )
+    p.add_argument(
+        '--ignore-missing-source',
+        action='store_true',
+        help='Ignore the sources missing from input GVF.'
+    )
     common.add_args_cleavage(p, enzyme_only=True)
     common.add_args_reference(p, genome=False, proteome=True)
     common.add_args_quiet(p)
@@ -97,7 +102,10 @@ def summarize_fasta(args:argparse.Namespace) -> None:
     source_order = {val:i for i,val in  enumerate(args.order_source.split(','))}\
         if args.order_source else None
 
-    summarizer = PeptidePoolSummarizer(order=source_order)
+    summarizer = PeptidePoolSummarizer(
+        order=source_order,
+        ignore_missing_source=args.ignore_missing_source
+    )
 
     for gvf in args.gvf:
         with open(gvf, 'rt') as handle:

--- a/test/integration/test_summarize_fasta.py
+++ b/test/integration/test_summarize_fasta.py
@@ -17,6 +17,7 @@ class TestSummarizeFasta(TestCaseIntegration):
         args.order_source = None
         args.cleavage_rule = 'trypsin'
         args.output_path = self.work_dir/'output.txt'
+        args.ignore_missing_source = False
         return args
 
     def test_summarize_fasta_case1(self):
@@ -33,6 +34,27 @@ class TestSummarizeFasta(TestCaseIntegration):
         args.noncoding_peptides = self.data_dir/'peptides/noncoding.fasta'
         args.annotation_gtf = self.data_dir/"annotation.gtf"
         args.proteome_fasta = self.data_dir/"translate.fasta"
+        cli.summarize_fasta(args)
+        files = {str(file.name) for file in self.work_dir.glob('*')}
+        expected = {args.output_path.name}
+        self.assertEqual(files, expected)
+
+    def test_summarize_fasta_case2(self):
+        """ summarize fasta case2 with sources missing """
+        args = self.create_base_args()
+        args.gvf = [
+            self.data_dir/'vep/vep_gSNP.gvf',
+            self.data_dir/'vep/vep_gINDEL.gvf',
+            self.data_dir/'reditools/reditools.gvf',
+            self.data_dir/'fusion/star_fusion.gvf',
+            self.data_dir/'circRNA/circ_rna.gvf'
+        ]
+        args.variant_peptides = self.data_dir/'peptides/variant.fasta'
+        args.noncoding_peptides = self.data_dir/'peptides/noncoding.fasta'
+        args.annotation_gtf = self.data_dir/"annotation.gtf"
+        args.proteome_fasta = self.data_dir/"translate.fasta"
+        args.order_source = 'gSNP,gINDEL,RNAEditingSite,Fusion,circRNA,rMATS'
+        args.ignore_missing_source = True
         cli.summarize_fasta(args)
         files = {str(file.name) for file in self.work_dir.glob('*')}
         expected = {args.output_path.name}


### PR DESCRIPTION
Argument `--ignore-missing-source` added to `summarizeFasta` so now sources not present in any GVF provided will be ignored. In the meta pipeline, we then can use the same source order string for all samples.

Closes #436 