### PR TITLE
Going back to not provide canonical peptides to each parallel task

### DIFF
--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -360,9 +360,6 @@ def call_variant_peptide(args:argparse.Namespace) -> None:
                 if i % 1000 == 0:
                     logger(f'{i} transcripts processed.')
 
-            if i > 200:
-                break
-
     caller.write_fasta()
 
 


### PR DESCRIPTION
To solve the RNA editing site hypermutated region issue in #483, we did two things to reduce the number of peptides that need to create the label `PeptideVariantGraph.call_variant_peptide`:

1. Filter candidate peptides based on min_mw, min_length and max_length.
2. Filter candidate peptides if they overlap with the canonical peptide pool.

Previously these two steps are done after the label with variant combinations are created.

Although `ray` is able to put object into shared memory, but seems like for each worker process, it's not instant to access the shared memory object. It doesn't make a deep copy of the data, but it still takes time. And our parallelization strategy is that every transcript is handled in individual task, then each task ends up to have the extra time to create the "copy" of the shared memory object of the canonical peptide pool. So this makes the program less efficient. I'm now going back to not provide the canonical peptide pool to each parallel task. This might make the program run a little slower, and have larger memory. But hopefully most of the peptides that have the problem of too many variant combinations are removed by 1. I actually think this is the case, because usually those are peptides that are too long.