### PR TITLE
Fix dockerfile: `--use-feature=in-tree-build` is no longer supported by pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN conda create -qy -p /usr/local\
     python==${PYTHON_VER}
 
 RUN cd /opt/moPepGen/ && \
-    pip install . --use-feature=in-tree-build
+    pip install .
 
 # Deploy the target tools into a base image
 FROM ubuntu:20.04


### PR DESCRIPTION
The command was added initially to remove some warning. Simply removing it seems to work.

Closes #502 