### PR TITLE
Count overlapping sequences for reverse in decoyFasta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - For circRNA, each reading frame subgraph is now replicated for 3 times in order to catch all variant peptides that read through the junction site. #514
 
+- For `decoyFasta`, overlapping decoy sequences are also counted and printed to the stdout when using reverse. #474
+
 ---
 
 ## [0.9.1] - 2022-07-27

--- a/moPepGen/cli/decoy_fasta.py
+++ b/moPepGen/cli/decoy_fasta.py
@@ -225,6 +225,8 @@ class DecoyFasta():
         fixed_indices = self.find_fixed_indices(seq.seq)
         if self.method == 'reverse':
             decoy_seq = self.reverse_sequence(seq.seq, fixed_indices)
+            if decoy_seq in self._target_pool or decoy_seq in self._decoy_pool:
+                self._summary.n_overlap += 1
         elif self.method == 'shuffle':
             attempts = 0
             while True:


### PR DESCRIPTION
Output looks like this:

```
[ 2022-07-29 11:01:15 ] moPepGen decoyFasta started
[ 2022-07-29 11:01:15 ] Input database FASTA file loaded.
[ 2022-07-29 11:01:15 ] Decoy sequences created.
[ 2022-07-29 11:01:15 ] Number of decoy sequences created: 105
[ 2022-07-29 11:01:15 ] Number of decoy sequences overlap with either target or decoy: 0
[ 2022-07-29 11:01:15 ] Decoy database written.
[ 2022-07-29 11:01:15 ] rss=64.32 MiB, vms=331.3 MiB, wallclock=0:00:00.860000, system=0:00:00.200000, cpu_usage=37.1%
```

Closes #474