### PR TITLE
Fix bruteForce to check whether a variant is stop altering

### DIFF
--- a/moPepGen/util/brute_force.py
+++ b/moPepGen/util/brute_force.py
@@ -152,8 +152,8 @@ class BruteForceVariantPeptideCaller():
         if -1 < loc.start < prev_cds_start:
             return False
         orf_index = cds_start % 3
-        i = loc.start - (loc.start - orf_index) % 3
-        while i < loc.end:
+        i = variant.location.start - (loc.start - orf_index) % 3
+        while i < variant.location.end:
             if self.tx_seq.seq[i:i+3] in ['TAA', 'TAG', 'TGA']:
                 return True
             i += 3


### PR DESCRIPTION
This is a bug in bruteForce that when checking whether a variant is stop altering, the reference sequence was not extracted correctly, so variants are labeled as stop altering incorrectly.

Can finally move on to a new batch of fuzz test

Closes #536