### PR TITLE
Patch for `enzymatic_cleave` function to skip X

### DIFF
--- a/moPepGen/aa/AminoAcidSeqRecord.py
+++ b/moPepGen/aa/AminoAcidSeqRecord.py
@@ -229,6 +229,8 @@ class AminoAcidSeqRecord(SeqRecord):
         start = 0
 
         def update_peptides(peptide):
+            if 'X' in peptide.seq:
+                return
             mol_wt = SeqUtils.molecular_weight(peptide.seq, 'protein')
             weight_flag = mol_wt > min_mw
             length_flag = len(peptide.seq) >= min_length \


### PR DESCRIPTION
This is a small patch to fix the `enzymatic_cleave` method of `aa.AminoAcidSeqRecord`. We don't actually use this function anywhere in `callVariant`, but I found it useful when getting all cleavage peptides from pyQUILTS and customProDBJ output.