### PR TITLE
Fix align variant for circRNA that `None` is returned because of different subgraph ID

### DIFF
--- a/moPepGen/svgraph/PeptideVariantGraph.py
+++ b/moPepGen/svgraph/PeptideVariantGraph.py
@@ -1001,6 +1001,7 @@ class PeptideVariantGraph():
                     start_gain = set()
                     orfs = []
                 elif start_indices:
+                    orf = orf.copy()
                     # carry over variants from the target node to the next
                     # node if a start codon is found.
                     start_gain = target_node.get_variants_at(
@@ -1026,6 +1027,7 @@ class PeptideVariantGraph():
                     start_gain = set()
                     orfs = []
                 elif start_indices:
+                    orf = orf.copy()
                     start_index = start_indices[-1]
                     start_gain = target_node.get_variants_at(start_index, start_index + 1)
                     fs_variants = target_node.get_variants_at(

--- a/moPepGen/svgraph/ThreeFrameTVG.py
+++ b/moPepGen/svgraph/ThreeFrameTVG.py
@@ -64,6 +64,10 @@ class ThreeFrameTVG():
         self.hypermutated_region_warned = hypermutated_region_warned
         self.cleavage_params = cleavage_params or params.CleavageParams('trypsin')
 
+    def is_circ_rna(self) -> bool:
+        """ If the graph is a circRNA """
+        return self.global_variant and self.global_variant.is_circ_rna()
+
     def add_default_sequence_locations(self):
         """ Add default sequence locations """
         self.seq.locations = [MatchedLocation(
@@ -1151,6 +1155,8 @@ class ThreeFrameTVG():
         # current subgraph. The only exception is for fusions, that incoming
         # node in the main graph is exclusively bond with the fusion donor.
         subgraph_checker = True
+        if self.is_circ_rna():
+            subgraph_checker = False
         # find the range of overlaps
         farthest = None
         if not node.get_reference_next():


### PR DESCRIPTION
Closes #588 