### PR TITLE
Version bump to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-## [0.9.5] - 2022-09-28
+## [0.10.0] - 2022-10-20
 
 ## Added
 

--- a/moPepGen/__init__.py
+++ b/moPepGen/__init__.py
@@ -5,7 +5,7 @@ import itertools
 from typing import Iterable, IO
 
 
-__version__ = '0.9.5'
+__version__ = '0.10.0'
 
 ## Error messages
 ERROR_INDEX_IN_INTRON = 'The genomic index seems to be in an intron'


### PR DESCRIPTION
For the batch of fuzz test I submitted two days ago, the 2,000 cases of comprehensive (coding/noncoding + snp, indel, circRNA, fusion and alt splice) all passed successfully. The 16,639/20,000 test cases of coding/noncoding + snp & indel only finished successfully without any issue. The snp & indel only is still running but I'll go ahead and bump the version and make a new release.