### PR TITLE
Fix bruteForce that variants at the accepter transcript and start with breakpoint not excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Failed to find the downstream exon start when the breakpoint is the first nucleotide before the exon start of a transcript on the negative strand. #603
 
+- In `bruteForce`, variants that start at the fusion breakpoint were not excluded. #604
+
 ## [0.10.0] - 2022-10-20
 
 ### Added

--- a/moPepGen/util/brute_force.py
+++ b/moPepGen/util/brute_force.py
@@ -298,7 +298,7 @@ class BruteForceVariantPeptideCaller():
                 inserted_intronic_region[self.tx_id].append(loc)
 
             if right_tx_id in pool \
-                    and any(x.location.start < right_breakpoint_tx
+                    and any(x.location.start <= right_breakpoint_tx
                         for x in pool[right_tx_id].transcriptional):
                 return True
 


### PR DESCRIPTION
Fixed #604 