### PR TITLE
Fix bruteForce: invalide variant included in fusion

### DIFF
--- a/moPepGen/util/brute_force.py
+++ b/moPepGen/util/brute_force.py
@@ -322,7 +322,8 @@ class BruteForceVariantPeptideCaller():
             if tx_id not in inserted_intronic_region:
                 return True
             for v in pool[tx_id].intronic:
-                if not any(x.is_superset(v.location) for x in inserted_intronic_region[tx_id]):
+                if not any(x.start < v.location.start and x.end > v.location.end
+                        for x in inserted_intronic_region[tx_id]):
                     return True
         return False
 


### PR DESCRIPTION
A small issue fixed for bruteForce. For fusions with intronic breakpoints, variants that start at the first inserted nucleotide or end at the last nucleotide of the inserted intronic region should not be included.

I think we are ready to make the release once this PR is merged.