### PR TITLE
Version bump 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-## [0.11.0] - 2023-1-12
+## [0.11.0] - 2023-1-29
 
 ### Fixed
 


### PR DESCRIPTION
Version is already updated so this just updated the release date. The last fuzz test all passed without any mismatches except those 'none' that failed when simulating the variant records before running callVariant or bruteForce.  Cheers and hope it performs as well on the actual samples!

```
                        pass    fail    none
coding_snv              5000    0       0
coding_indel            5000    0       0
noncoding_snv           5000    0       0
noncoding_indel         5000    0       0
coding_comprehensive    989     0       11
noncoding_comprehensive 991     0       9
```