### PR TITLE
Fix callVariant that some command line arguments not passed to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.11.5] - 2023-3-5
+
+### Fixed
+
+- Fixed `callVariant` that the command line argument `--max-variants-per-node` and `--additional-variants-per-misc` not passed to it and the default value was always used.
+
 ## [0.11.4] - 2023-2-23
 
 ### Fixed

--- a/moPepGen/__init__.py
+++ b/moPepGen/__init__.py
@@ -5,7 +5,7 @@ import itertools
 from typing import Iterable, IO
 
 
-__version__ = '0.11.4'
+__version__ = '0.11.5'
 
 ## Error messages
 ERROR_INDEX_IN_INTRON = 'The genomic index seems to be in an intron'

--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -127,12 +127,12 @@ class VariantPeptideCaller():
             miscleavage=int(args.miscleavage),
             min_mw=float(args.min_mw),
             min_length=args.min_length,
-            max_length=args.max_length
+            max_length=args.max_length,
+            max_variants_per_node = args.max_variants_per_node,
+            additional_variants_per_misc = args.additional_variants_per_misc,
+            min_nodes_to_collapse = args.min_nodes_to_collapse,
+            naa_to_collapse = args.naa_to_collapse
         )
-        self.max_variants_per_node:int = args.max_variants_per_node
-        self.additional_variants_per_misc:int = args.additional_variants_per_misc
-        self.min_nodes_to_collapse:int = args.min_nodes_to_collapse
-        self.naa_to_collapse:int = args.naa_to_collapse
         self.noncanonical_transcripts = args.noncanonical_transcripts
         self.invalid_protein_as_noncoding:bool = args.invalid_protein_as_noncoding
         self.verbose = args.verbose_level


### PR DESCRIPTION
`--max-variants-per-node` and `--additional-variants-per-misc` not passed to callVariant successfully so the default values were always used. The data that were already run are fine because default values were used.