### PR TITLE
Set minimal version for index to 0.12.0

### DIFF
--- a/moPepGen/version.py
+++ b/moPepGen/version.py
@@ -6,7 +6,7 @@ import Bio
 from moPepGen import __version__
 
 
-MINIMAL_VERSION = '0.0.1'
+MINIMAL_VERSION = '0.12.0'
 
 class MetaVersion():
     """ Versions """


### PR DESCRIPTION
Because of the new added selenocysteine, old genome index are no longer supported. Setting the minimal version to 0.12.0