### PR TITLE
Also add "canonical" peptides to blacklist when calling from fusion in bruteForce

### DIFF
--- a/moPepGen/cli/call_noncoding_peptide.py
+++ b/moPepGen/cli/call_noncoding_peptide.py
@@ -194,7 +194,7 @@ def call_noncoding_peptide_main(tx_id:str, tx_model:TranscriptAnnotationModel,
     peptides = pgraph.call_variant_peptides(
         check_variants=False,
         check_orf=True,
-        blacklist=canonical_peptides,
+        denylist=canonical_peptides,
         orf_assignment=orf_assignment,
         w2f=w2f_reassignment
     )

--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -215,7 +215,7 @@ def call_variant_peptides_wrapper(tx_id:str,
     """ wrapper function to call variant peptides """
     peptide_pool:List[Set[aa.AminoAcidSeqRecord]] = []
     main_peptides = None
-    blacklist = call_canonical_peptides(
+    denylist = call_canonical_peptides(
         tx_id=tx_id, ref=reference_data, tx_seq=tx_seqs[tx_id],
         cleavage_params=cleavage_params, truncate_sec=truncate_sec,
         w2f=w2f_reassignment
@@ -232,7 +232,7 @@ def call_variant_peptides_wrapper(tx_id:str,
                     max_adjacent_as_mnv=max_adjacent_as_mnv,
                     truncate_sec=truncate_sec,
                     w2f=w2f_reassignment,
-                    blacklist=blacklist
+                    denylist=denylist
                 )
                 peptide_pool.append(main_peptides)
         except:
@@ -261,7 +261,7 @@ def call_variant_peptides_wrapper(tx_id:str,
                 variant=variant, variant_pool=variant_pool, ref=reference_data,
                 tx_seqs=tx_seqs, gene_seqs=gene_seqs, cleavage_params=cleavage_params,
                 max_adjacent_as_mnv=max_adjacent_as_mnv, w2f_reassignment=w2f_reassignment,
-                blacklist=blacklist
+                denylist=denylist
             )
         except:
             logger(
@@ -274,14 +274,14 @@ def call_variant_peptides_wrapper(tx_id:str,
     peptide_pool.append(peptides)
     peptides = set()
     if main_peptides:
-        blacklist.update([str(x.seq) for x in main_peptides])
+        denylist.update([str(x.seq) for x in main_peptides])
     for circ_model in variant_series.circ_rna:
         try:
             _peptides = call_peptide_circ_rna(
                 record=circ_model, variant_pool=pool, gene_seqs=gene_seqs,
                 cleavage_params=cleavage_params,
                 max_adjacent_as_mnv=max_adjacent_as_mnv,
-                w2f_reassignment=w2f_reassignment, blacklist=blacklist
+                w2f_reassignment=w2f_reassignment, denylist=denylist
             )
         except:
             logger(f"Exception raised from {circ_model.id}")
@@ -450,7 +450,7 @@ def call_peptide_main(tx_id:str, tx_variants:List[seqvar.VariantRecord],
         gene_seqs:Dict[str, dna.DNASeqRecordWithCoordinates],
         cleavage_params:params.CleavageParams,
         max_adjacent_as_mnv:bool, truncate_sec:bool, w2f:bool,
-        blacklist:Set[str]
+        denylist:Set[str]
         ) -> Set[aa.AminoAcidSeqRecord]:
     """ Call variant peptides for main variants (except cirRNA). """
     tx_model = ref.anno.transcripts[tx_id]
@@ -476,7 +476,7 @@ def call_peptide_main(tx_id:str, tx_variants:List[seqvar.VariantRecord],
 
     pgraph.create_cleavage_graph()
     return pgraph.call_variant_peptides(
-        blacklist=blacklist,
+        denylist=denylist,
         truncate_sec=truncate_sec,
         w2f=w2f,
         check_external_variants=True
@@ -488,7 +488,7 @@ def call_peptide_fusion(variant:seqvar.VariantRecord,
         tx_seqs:Dict[str, dna.DNASeqRecordWithCoordinates],
         gene_seqs:Dict[str, dna.DNASeqRecordWithCoordinates],
         cleavage_params:params.CleavageParams, max_adjacent_as_mnv:bool,
-        w2f_reassignment:bool, blacklist:Set[str]
+        w2f_reassignment:bool, denylist:Set[str]
         ) -> Set[aa.AminoAcidSeqRecord]:
     """ Call variant peptides for fusion """
     tx_id = variant.location.seqname
@@ -529,7 +529,7 @@ def call_peptide_fusion(variant:seqvar.VariantRecord,
     pgraph = dgraph.translate()
     pgraph.create_cleavage_graph()
     return pgraph.call_variant_peptides(
-        blacklist=blacklist,
+        denylist=denylist,
         w2f=w2f_reassignment,
         check_external_variants=True
     )
@@ -538,7 +538,7 @@ def call_peptide_circ_rna(record:circ.CircRNAModel,
         variant_pool:seqvar.VariantRecordPool,
         gene_seqs:Dict[str, dna.DNASeqRecordWithCoordinates],
         cleavage_params:params.CleavageParams, max_adjacent_as_mnv:bool,
-        w2f_reassignment:bool, blacklist:Set[str]
+        w2f_reassignment:bool, denylist:Set[str]
         )-> Set[aa.AminoAcidSeqRecord]:
     """ Call variant peptides from a given circRNA """
     gene_id = record.gene_id
@@ -583,6 +583,6 @@ def call_peptide_circ_rna(record:circ.CircRNAModel,
     pgraph = cgraph.translate()
     pgraph.create_cleavage_graph()
     return pgraph.call_variant_peptides(
-        blacklist=blacklist, circ_rna=record,
+        denylist=denylist, circ_rna=record,
         w2f=w2f_reassignment, check_external_variants=True
     )

--- a/moPepGen/svgraph/PeptideVariantGraph.py
+++ b/moPepGen/svgraph/PeptideVariantGraph.py
@@ -41,7 +41,7 @@ class PeptideVariantGraph():
             known_orf:List[int,int], cleavage_params:params.CleavageParams=None,
             orfs:Set[Tuple[int,int]]=None, reading_frames:List[PVGNode]=None,
             orf_id_map:Dict[int,str]=None, cds_start_nf:bool=False,
-            hypermutated_region_warned:bool=False, blacklist:Set[str]=None,
+            hypermutated_region_warned:bool=False, denylist:Set[str]=None,
             global_variant:VariantRecord=None, subgraphs:SubgraphTree=None,
             gene_id:str=None):
         """ Construct a PeptideVariantGraph """
@@ -57,7 +57,7 @@ class PeptideVariantGraph():
         self.orf_id_map = orf_id_map or {}
         self.cds_start_nf = cds_start_nf
         self.hypermutated_region_warned = hypermutated_region_warned
-        self.blacklist = blacklist or set()
+        self.denylist = denylist or set()
         self.cleavage_params = cleavage_params or params.CleavageParams()
         self.global_variant = global_variant
         self.subgraphs = subgraphs
@@ -778,7 +778,7 @@ class PeptideVariantGraph():
         self.orf_id_map = {v:f"ORF{i+1}" for i,v in enumerate(orfs)}
 
     def call_variant_peptides(self, check_variants:bool=True,
-            check_orf:bool=False, keep_all_occurrence:bool=True, blacklist:Set[str]=None,
+            check_orf:bool=False, keep_all_occurrence:bool=True, denylist:Set[str]=None,
             circ_rna:circ.CircRNAModel=None, orf_assignment:str='max',
             truncate_sec:bool=False, w2f:bool=False, check_external_variants:bool=True
             ) -> Set[aa.AminoAcidSeqRecord]:
@@ -800,7 +800,7 @@ class PeptideVariantGraph():
         if self.is_circ_rna() and not circ_rna:
             raise ValueError('`circ_rna` must be given.')
 
-        self.blacklist = blacklist or set()
+        self.denylist = denylist or set()
         cur = PVGCursor(None, self.root, True, [], [])
         queue:Deque[Tuple[PVGNode,bool]] = deque([cur])
         peptide_pool = VariantPeptideDict(
@@ -900,7 +900,7 @@ class PeptideVariantGraph():
                 check_variants=traversal.check_variants,
                 is_start_codon=False,
                 additional_variants=additional_variants,
-                blacklist=self.blacklist,
+                denylist=self.denylist,
                 leading_node=target_node,
                 subgraphs=self.subgraphs
             )
@@ -983,7 +983,7 @@ class PeptideVariantGraph():
                 check_variants=traversal.check_variants,
                 is_start_codon=True,
                 additional_variants=additional_variants,
-                blacklist=self.blacklist,
+                denylist=self.denylist,
                 leading_node=target_node,
                 subgraphs=self.subgraphs
             )
@@ -1162,7 +1162,7 @@ class PeptideVariantGraph():
                 check_variants=traversal.check_variants,
                 is_start_codon=is_start_codon,
                 additional_variants=additional_variants,
-                blacklist=self.blacklist,
+                denylist=self.denylist,
                 leading_node=target_node,
                 subgraphs=self.subgraphs,
                 circ_rna=traversal.circ_rna

--- a/moPepGen/util/brute_force.py
+++ b/moPepGen/util/brute_force.py
@@ -187,13 +187,13 @@ class BruteForceVariantPeptideCaller():
         else:
             self.start_index = 3
 
-    def peptide_is_valid(self, peptide:str, blacklist:List[str], check_canonical) -> bool:
+    def peptide_is_valid(self, peptide:str, denylist:List[str], check_canonical) -> bool:
         """ Check whether the peptide is valid """
         if check_canonical \
                 and self.canonical_peptides \
                 and peptide in self.canonical_peptides:
             return False
-        if peptide in blacklist:
+        if peptide in denylist:
             return False
         min_len = self.cleavage_params.min_length
         max_len = self.cleavage_params.max_length
@@ -888,7 +888,7 @@ class BruteForceVariantPeptideCaller():
         return sec_positions
 
     def call_peptides_main(self, variants:seqvar.VariantRecordPool,
-            blacklist:Set[str], check_variants:bool, check_canonical:bool):
+            denylist:Set[str], check_variants:bool, check_canonical:bool):
         """ Call peptide main """
         variant_peptides = set()
         tx_model = self.tx_model
@@ -996,7 +996,7 @@ class BruteForceVariantPeptideCaller():
                             and tx_rhs + 3 > len(seq):
                         continue
                     peptide = aa_seq.seq[lhs:rhs]
-                    if str(peptide) in blacklist:
+                    if str(peptide) in denylist:
                         continue
                     if check_variants:
                         effective_variants = self.get_effective_variants(
@@ -1015,7 +1015,7 @@ class BruteForceVariantPeptideCaller():
                         effective_variants = []
 
                     peptide_seqs = self.translational_modification(
-                        peptide, lhs, tx_lhs, effective_variants, blacklist,
+                        peptide, lhs, tx_lhs, effective_variants, denylist,
                         check_variants, check_canonical
                     )
                     for peptide_seq in peptide_seqs:
@@ -1024,7 +1024,7 @@ class BruteForceVariantPeptideCaller():
 
     def translational_modification(self, seq:Seq, lhs:int, tx_lhs:int,
             effective_variants:List[VariantRecordWithCoordinate],
-            blacklist:List[str], check_variants:bool, check_canonical:bool
+            denylist:List[str], check_variants:bool, check_canonical:bool
             ) -> Iterable[str]:
         """ Apply any modification that could happen during translation. """
         candidates = []
@@ -1072,7 +1072,7 @@ class BruteForceVariantPeptideCaller():
                         candidates.append(seq_mod[1:])
 
         for candidate in candidates:
-            if self.peptide_is_valid(candidate, blacklist, check_canonical):
+            if self.peptide_is_valid(candidate, denylist, check_canonical):
                 yield str(candidate)
 
     def generate_variant_comb(self, fusion:bool, circ_rna:bool
@@ -1141,21 +1141,21 @@ class BruteForceVariantPeptideCaller():
         """ Call variant peptides """
         empty_pool = seqvar.VariantRecordPool()
         empty_pool[self.tx_id] = seqvar.TranscriptionalVariantSeries()
-        blacklist = self.call_peptides_main(empty_pool, set(), False, False)
+        denylist = self.call_peptides_main(empty_pool, set(), False, False)
         main_peptides = set()
 
         for comb in self.generate_variant_comb(fusion=False, circ_rna=False):
-            peptides = self.call_peptides_main(comb, blacklist, True, True)
+            peptides = self.call_peptides_main(comb, denylist, True, True)
             self.variant_peptides.update(peptides)
             main_peptides.update(peptides)
 
         for comb in self.generate_variant_comb(fusion=True, circ_rna=False):
-            peptides = self.call_peptides_main(comb, blacklist, True, True)
+            peptides = self.call_peptides_main(comb, denylist, True, True)
             self.variant_peptides.update(peptides)
 
-        blacklist.update(main_peptides)
+        denylist.update(main_peptides)
         for comb in self.generate_variant_comb(fusion=False, circ_rna=True):
-            peptides = self.call_peptides_main(comb, blacklist, True, True)
+            peptides = self.call_peptides_main(comb, denylist, True, True)
             self.variant_peptides.update(peptides)
 
 def create_mnvs(pool:seqvar.VariantRecordPool, max_adjacent_as_mnv:int


### PR DESCRIPTION
To be consistent with callVariant