### PR TITLE
Fix merged MNV, transcript ID not set for intronic ones

### DIFF
--- a/moPepGen/seqvar/VariantRecord.py
+++ b/moPepGen/seqvar/VariantRecord.py
@@ -62,8 +62,10 @@ def create_mnv_from_adjacent(variants:Iterable[VariantRecord]) -> VariantRecord:
             seqname = v.location.seqname
             if 'TRANSCRIPT_ID' in v.attrs:
                 gene_id = seqname
+                tx_id = v.attrs['TRANSCRIPT_ID']
             else:
                 gene_id = v.attrs['GENE_ID']
+                tx_id = seqname
             start = v.location.start
             ref = v.ref
             alt = v.alt
@@ -74,17 +76,22 @@ def create_mnv_from_adjacent(variants:Iterable[VariantRecord]) -> VariantRecord:
             var_ids.append(v.id)
     end = variants[-1].location.end
 
+    attrs = {
+        'INDIVIDUAL_VARIANT_IDS': var_ids,
+        'MERGED_MNV': True
+    }
+    if seqname == tx_id:
+        attrs['GENE_ID'] = gene_id
+    else:
+        attrs['TRANSCRIPT_ID'] = tx_id
+
     return VariantRecord(
         location=FeatureLocation(start, end, seqname=seqname),
         ref=ref,
         alt=alt,
         _type='MNV',
         _id=f"MNV-{start}-{ref}-{end}",
-        attrs={
-            'GENE_ID': gene_id,
-            'INDIVIDUAL_VARIANT_IDS': var_ids,
-            'MERGED_MNV': True
-        }
+        attrs=attrs
     )
 
 def find_mnvs_from_adjacent_variants(variants:List[VariantRecord],


### PR DESCRIPTION
And issue was reported that with the latest one, summarizeFasta failed with the following error:

```
moPepGen.err.VariantSourceNotFoundError: Variant source not found transcript [ENSG00000156299.13] variant [ENSG00000156299.13-SNV-293744-G-A]. Please verify all GVF files are imported
```

The variant peptide that causes this error from the fasta file is below:

```
>ENST00000469412.5|SE_292994|ENSG00000156299.13-SNV-293744-G-A|ENSG00000156299.13-SNV-293745-G-T|8
MGPGSKFAGYCR
```

The two SNVs are intronic, and are incorporated because of the AltSplice, and are adjacent variants, and are merged as a MNV. And when the MNV is created, the transcript ID was not set in the attrs, so when the variant peptide label is created, it could not know what transcript they come from.

With this fixed, the peptide record is as below, so should be handled properly by summarizeFasta

```
>ENST00000469412.5|SNV-293744-G-A|SNV-293745-G-T|SE_292994|4
MGPGSKFAGYCR
```