### PR TITLE
Fix ThreeFrameTVG with unique subgraph end node

### DIFF
--- a/moPepGen/svgraph/ThreeFrameTVG.py
+++ b/moPepGen/svgraph/ThreeFrameTVG.py
@@ -1737,8 +1737,6 @@ class ThreeFrameTVG():
                 queue.appendleft(cur)
                 continue
 
-            cur_seq = cur.seq.seq
-
             self.align_variants(cur)
 
             self.collapse_equivalent_nodes(cur)


### PR DESCRIPTION
We caught this issue when comparing mpg output vs pyquilts, and found mpg missed a peptide. Further digging found  the TVG wasn't aligned correctly, resulting some nodes being not multiple of 3. The reason for this is, we previously caught an issue when the subgraph has multiple end nodes (usually when there is a mutation very closed to the end of the subgraph), we have to merge the nodes with the downstream node. This was done in 8c4ca2c. This actually caused an issue when the subgraph's end node is unique. So here we'll only do that when the end nodes of a subgraph is multiple.

I'm running a new set of fuzz test and it seems to work. Will update.