### PR TITLE
fix (ThreeFrameTVG): wrong variable name used, .in_edge -> .in_edges

### DIFF
--- a/moPepGen/svgraph/ThreeFrameTVG.py
+++ b/moPepGen/svgraph/ThreeFrameTVG.py
@@ -1197,7 +1197,7 @@ class ThreeFrameTVG():
         for in_node in in_nodes:
             if len(in_node.out_edges) > 1:
                 new_in_node = in_node.copy()
-                for edge in in_node.in_edge:
+                for edge in in_node.in_edges:
                     upstream = edge.in_node
                     self.add_edge(upstream, new_in_node, edge.type)
                 new_in_node.append_right(node)


### PR DESCRIPTION
## Description

Closes #729 

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [ ] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
