### PR TITLE
fix callAltTranslation: only peptides with SECT got output

### DIFF
--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -443,7 +443,8 @@ def call_canonical_peptides(tx_id:str, ref:params.ReferenceData,
     pgraph = dgraph.translate()
     pgraph.create_cleavage_graph()
     peptides = pgraph.call_variant_peptides(
-        check_variants=False, truncate_sec=truncate_sec, w2f=w2f
+        check_variants=False, truncate_sec=truncate_sec, w2f=w2f,
+        check_external_variants=False
     )
     return {str(x.seq) for x in peptides}
 

--- a/moPepGen/svgraph/PeptideVariantGraph.py
+++ b/moPepGen/svgraph/PeptideVariantGraph.py
@@ -813,9 +813,9 @@ class PeptideVariantGraph():
             cleavage_params=self.cleavage_params
         )
         traversal = PVGTraversal(
-            check_variants=check_variants, check_orf=check_orf,
-            queue=queue, pool=peptide_pool, circ_rna=circ_rna,
-            orf_assignment=orf_assignment
+            check_variants=check_external_variants,
+            check_orf=check_orf, queue=queue, pool=peptide_pool,
+            circ_rna=circ_rna, orf_assignment=orf_assignment
         )
 
         if self.has_known_orf():
@@ -859,7 +859,8 @@ class PeptideVariantGraph():
         peptide_pool.translational_modification(w2f, self.denylist)
 
         return peptide_pool.get_peptide_sequences(
-            keep_all_occurrence=keep_all_occurrence, orf_id_map=self.orf_id_map
+            keep_all_occurrence=keep_all_occurrence, orf_id_map=self.orf_id_map,
+            check_variants=check_variants
         )
 
     def call_and_stage_known_orf(self, cursor:PVGCursor,

--- a/test/unit/test_peptide_variant_graph.py
+++ b/test/unit/test_peptide_variant_graph.py
@@ -550,7 +550,10 @@ class TestPeptideVariantGraph(unittest.TestCase):
         }
         graph_id = 'ENST0001'
         graph, _ = create_pgraph(data, graph_id, )
-        peptides = graph.call_variant_peptides(check_variants=False, check_orf=True)
+        peptides = graph.call_variant_peptides(
+            check_variants=False, check_orf=True,
+            check_external_variants=False
+        )
 
         received = {str(x.seq) for x in peptides}
         expected = {'MSSSK', 'MSSYK', 'SSSSR', 'SSYK', 'SSSK'}

--- a/test/unit/test_variant_peptide_dict.py
+++ b/test/unit/test_variant_peptide_dict.py
@@ -18,6 +18,7 @@ def create_variant_peptide_dict(tx_id, data) -> VariantPeptideDict:
             label = vpi.create_variant_peptide_id(tx_id, variants, None)
             is_pure_circ_ran = len(variants) == 1 and list(variants)[0].is_circ_rna()
             metadata = VariantPeptideMetadata(label, it[1], is_pure_circ_ran)
+            metadata.has_variants = bool(variants)
             metadatas.add(metadata)
         peptides[seq] = metadatas
     return VariantPeptideDict(tx_id=tx_id, peptides=peptides)


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

Closes #...  <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
