### PR TITLE
fix (generateIndex): skip * when generating canonical peptide pool

### DIFF
--- a/moPepGen/aa/AminoAcidSeqDict.py
+++ b/moPepGen/aa/AminoAcidSeqDict.py
@@ -103,6 +103,11 @@ class AminoAcidSeqDict(dict):
                 cds_start_nf = False
             if protein.seq.startswith('X'):
                 protein.seq = protein.seq.lstrip('X')
+
+            stop_site = protein.seq.find('*')
+            if stop_site > -1:
+                protein = protein[:stop_site]
+
             try:
                 peptides = protein.enzymatic_cleave(
                     rule=rule,


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

For some reason, there is a protein sequence in the mouse proteome FASTA file that has a * symbol, which messes up `generateIndex` because biopython can't get its molecular weight. But it's strange that it didn't give us error before.

Closes #...  <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [x] All test cases passed locally.
