### PR TITLE
End-inclusion VEP insertions on negative strand

### DIFF
--- a/moPepGen/parser/VEPParser.py
+++ b/moPepGen/parser/VEPParser.py
@@ -173,13 +173,19 @@ class VEPRecord():
                 if len(allele) > 1: # insertion
                     # Sometimes insertions are reported by VEP in the end-inclusion
                     # way (e.g., C -> TACC), which needs to be converted into
-                    # start-inclusion (A -> ATAC)
-                    if genome[chrom_seqname].seq[alt_start_genomic] != allele[-1]:
-                        raise ValueError(f"Don't know how to process this variant: {self}")
-                    alt_start -= 1
-                    alt_end = alt_start + 1
-                    ref = str(seq.seq[alt_start])
-                    alt = ref + allele[:-1]
+                    # start-inclusion (A -> ATAC) for variants on + strand genes.
+                    if strand == 1:
+                        if seq.seq[alt_start] != allele[-1]:
+                            raise ValueError(f"Don't know how to process this variant: {self}")
+                        alt_start -= 1
+                        alt_end = alt_start + 1
+                        ref = str(seq.seq[alt_start])
+                        alt = ref + allele[:-1]
+                    else:
+                        if seq.seq[alt_start] != allele[0]:
+                            raise ValueError(f"Don't know how to process this variant: {self}")
+                        ref = str(seq.seq[alt_start])
+                        alt = allele
                 else: # SNV
                     ref = str(seq.seq[alt_start])
                     alt = allele


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

Previously in #767 we fixed the issue that VEP uses end-inclusion for some insertions but we forgot about the strand issue. For variants in genes on the - strand, the end-inclusion format becomes start-inclusion after reverse complement.

Closes #766

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [x] All test cases passed locally.
