### PR TITLE
Stop lost variant missed

### DIFF
--- a/moPepGen/svgraph/PeptideVariantGraph.py
+++ b/moPepGen/svgraph/PeptideVariantGraph.py
@@ -1005,6 +1005,9 @@ class PeptideVariantGraph():
                     for variant in target_node.variants:
                         if variant.variant.is_frameshifting():
                             cur_start_gain.add(variant.variant)
+                        if variant.location.start > start_index \
+                                and variant.is_stop_altering:
+                            cur_start_gain.add(variant.variant)
                     cur_cleavage_gain = copy.copy(cleavage_gain)
                     cleavage_gain_down = out_node.get_cleavage_gain_from_downstream()
                     cur_cleavage_gain.extend(cleavage_gain_down)


### PR DESCRIPTION
# Description
<!--- Briefly describe the changes included in this pull request  --->

When the stop lost mutation is in the same node as the start codon, it was not passed to downstream nodes. 

Closes #...  <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [x] All test cases passed locally.
