### PR TITLE
doc (moPepGen): version bump to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-## [1.2.1] - 2023-07-14
+## [1.2.0] - 2023-08-03
+
+### Fixed
+
+- Fixed that reference source are not recognized. Switched to use upper case values. #758
+
+- Fixed `generateIndex` that symlink was not created properly for GTF with `--gtf-symlink`.
+
+- Fixed matplotlib warning message #742
+
+- Fixed `parseVEP` that insertions not parsed successfully if the location is a single base. #766
+
+- Fixed `callVariant` that peptides with upstream cleavage altering mutations were not called. #670
 
 - Fixed fuzzTest to take multiple CPUs and use temporary directory.
 
@@ -25,20 +37,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed that in circRNA, cleavage gain from upstream node is added to the the wrong ORF. #783
 
 - Fixed callVariant that `fit_into_codon` terminated early in fusion transcripts when there donor has a frameshift and accepter has a variant right after the breakpoint. #786
-
-## [1.2.0] - 2023-07-04
-
-### Fixed
-
-- Fixed that reference source are not recognized. Switched to use upper case values. #758
-
-- Fixed `generateIndex` that symlink was not created properly for GTF with `--gtf-symlink`.
-
-- Fixed matplotlib warning message #742
-
-- Fixed `parseVEP` that insertions not parsed successfully if the location is a single base. #766
-
-- Fixed `callVariant` that peptides with upstream cleavage altering mutations were not called. #670
 
 ## [1.1.0] - 2023-06-28
 

--- a/moPepGen/__init__.py
+++ b/moPepGen/__init__.py
@@ -5,7 +5,7 @@ import itertools
 from typing import Iterable, IO
 
 
-__version__ = '1.2.1'
+__version__ = '1.2.0'
 
 ## Error messages
 ERROR_INDEX_IN_INTRON = 'The genomic index seems to be in an intron'


### PR DESCRIPTION
## Description

I thought we had 1.2.0 already but I must have forgotten to make that release. So back to 1.2.0

Closes #...  <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [x] All test cases passed locally.
