### PR TITLE
Update splitFasta and summarizeFasta to accept source combinations in --order-source

### DIFF
--- a/moPepGen/aa/VariantPeptideLabel.py
+++ b/moPepGen/aa/VariantPeptideLabel.py
@@ -75,6 +75,10 @@ class VariantSourceSet(set):
             return False
         this = self.to_int()
         that = other.to_int()
+        if len(this) > len(that):
+            return True
+        if len(this) < len(that):
+            return False
         for i, j in zip(this, that):
             if i > j:
                 return True
@@ -96,7 +100,10 @@ class VariantSourceSet(set):
 
     def to_int(self, sort=True) -> Iterable[int]:
         """ to int """
-        source_int = {self.levels_map[x] for x in self}
+        try:
+            source_int = {self.levels_map[frozenset(self)]}
+        except KeyError:
+            source_int = {self.levels_map[x] for x in self}
         if sort:
             source_int = list(source_int)
             source_int.sort()

--- a/moPepGen/cli/split_fasta.py
+++ b/moPepGen/cli/split_fasta.py
@@ -133,11 +133,15 @@ def split_fasta(args:argparse.Namespace) -> None:
     if args.order_source:
         source_order = {}
         for i,val in enumerate(args.order_source.split(',')):
-            if val in source_order:
+            if '-' in val:
+                source = frozenset(val.split('-'))
+            else:
+                source = val
+            if source in source_order:
                 raise ValueError(
-                    f"Non-unique value found from `--group-source`: {val}"
+                    f"Non-unique value found from `--group-source`: {source}"
                 )
-            source_order[val] = i
+            source_order[source] = i
     else:
         source_order = None
 

--- a/moPepGen/cli/summarize_fasta.py
+++ b/moPepGen/cli/summarize_fasta.py
@@ -158,8 +158,20 @@ def summarize_fasta(args:argparse.Namespace) -> None:
             coding_tx.add(tx_id)
     del anno
 
-    source_order = {val:i for i,val in enumerate(args.order_source.split(','))}\
-        if args.order_source else None
+    if args.order_source:
+        source_order = {}
+        for i,val in enumerate(args.order_source.split(',')):
+            if '-' in val:
+                source = frozenset(val.split('-'))
+            else:
+                source = val
+            if source in source_order:
+                raise ValueError(
+                    f"Non-unique value found from `--group-source`: {source}"
+                )
+            source_order[source] = i
+    else:
+        source_order = None
 
     group_map = None
     if args.group_source:

--- a/test/integration/test_split_fasta.py
+++ b/test/integration/test_split_fasta.py
@@ -176,3 +176,37 @@ class TestSplitDatabase(TestCaseIntegration):
             'test_Noncoding.fasta', 'test_ALT.fasta'
         }
         self.assertEqual(files, expected)
+
+    def test_split_fasta_source_order_comb(self):
+        """ test splitFasta with source order of combinations """
+        args = self.create_base_args()
+        args.gvf = [
+            self.data_dir/'vep/vep_gSNP.gvf',
+            self.data_dir/'vep/vep_gINDEL.gvf',
+            self.data_dir/'reditools/reditools.gvf',
+            self.data_dir/'fusion/star_fusion.gvf',
+            self.data_dir/'circRNA/circ_rna.gvf'
+        ]
+        args.variant_peptides = self.data_dir/'peptides/variant.fasta'
+        args.noncoding_peptides = self.data_dir/'peptides/noncoding.fasta'
+        args.alt_translation_peptides = self.data_dir/'peptides/alt_translation.fasta'
+        args.annotation_gtf = self.data_dir/'annotation.gtf'
+        args.proteome_fasta = self.data_dir/'translate.fasta'
+        args.group_source = [
+            'ALT:SECT,CodonReassign',
+            'NotCirc:gSNP,gINDEL,sSNV,sINDEL,Fusion,altSplice,RNAEditingSite'
+        ]
+        args.order_source = ','.join([
+            'NotCir',
+            'ALT',
+            'NotCirc-ALT',
+            'Noncoding',
+            'Noncoding-NotCirc',
+            'Noncoding-ALT',
+            'circRNA',
+            'circRNA-ALT',
+            'circRNA-NotCirc',
+            'Noncoding-circRNA'
+        ])
+        args.max_source_groups = 2
+        cli.split_fasta(args)

--- a/test/integration/test_summarize_fasta.py
+++ b/test/integration/test_summarize_fasta.py
@@ -87,3 +87,41 @@ class TestSummarizeFasta(TestCaseIntegration):
             print(cmd)
             print(res.stderr.decode('utf-8'))
             raise
+
+    def test_summarize_fasta_order_source_comb(self):
+        """ summarize fasta case2 with order source of combinations """
+        args = self.create_base_args()
+        args.gvf = [
+            self.data_dir/'vep/vep_gSNP.gvf',
+            self.data_dir/'vep/vep_gINDEL.gvf',
+            self.data_dir/'alternative_splicing/alternative_splicing.gvf',
+            self.data_dir/'reditools/reditools.gvf',
+            self.data_dir/'fusion/star_fusion.gvf',
+            self.data_dir/'circRNA/circ_rna.gvf'
+        ]
+        args.variant_peptides = self.data_dir/'peptides/variant.fasta'
+        args.noncoding_peptides = self.data_dir/'peptides/noncoding.fasta'
+        args.alt_translation_peptides = None
+        args.annotation_gtf = self.data_dir/"annotation.gtf"
+        args.proteome_fasta = self.data_dir/"translate.fasta"
+        args.group_source = [
+            'ALT:SECT,CodonReassign',
+            'NotCirc:gSNP,gINDEL,Fusion,AlternativeSplicing,RNAEditingSite'
+        ]
+        args.order_source = ','.join([
+            'NotCir',
+            'ALT',
+            'NotCirc-ALT',
+            'Noncoding',
+            'Noncoding-NotCirc',
+            'Noncoding-ALT',
+            'circRNA',
+            'circRNA-ALT',
+            'circRNA-NotCirc',
+            'Noncoding-circRNA'
+        ])
+        args.ignore_missing_source = True
+        cli.summarize_fasta(args)
+        files = {str(file.name) for file in self.work_dir.glob('*')}
+        expected = {args.output_path.name}
+        self.assertEqual(files, expected)


### PR DESCRIPTION
## Description

As discussed, we want to specify the order of specific combinations of sources in `--order-source`. So here I updated both `splitFasta` and `summarizeFasta` to do so.

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
