### PR TITLE
Fix brute force to shift insertion to end inclusion for noncoding transcripts

### DIFF
--- a/moPepGen/util/brute_force.py
+++ b/moPepGen/util/brute_force.py
@@ -1230,10 +1230,10 @@ def fix_indel_after_start_codon(pool:seqvar.VariantRecordPool,
         chrom = tx_model.transcript.chrom
         tx_seq = tx_model.get_transcript_sequence(ref.genome[chrom])
 
-        if not tx_model.cds:
-            continue
-
-        start = tx_seq.orf.start
+        if tx_seq.orf:
+            start = tx_seq.orf.start
+        else:
+            start = 0
         for v in pool[tx_id].transcriptional:
             if v.location.start == start + 2 \
                     and (v.is_insertion() or v.is_deletion()) \


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

Found by fuzz test. In bruteForce, insertions on noncoding transcripts after the 3rd nucleotide of the transcript were not shifted to end inclusion. So as a consequence, downstream indel at the 4th nucleotide can not be combined with it as "MNV".

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
