### PR TITLE
Fix parseVEP to handle insertions in star-inclusion format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Updated `splitFasta` and `summarizeFasta` to accept source combinations in `--order-source`.
 
-- Fixed parseCIRCexplorer so the exon/intron indices in variant IDs are sorted correctly.
+- Fixed `parseCIRCexplorer` so the exon/intron indices in variant IDs are sorted correctly.
+
+- Fixed `parseVEP` to handle insertions in start-inclusion. #840
 
 ## [1.2.1] - 2023-10-05
 

--- a/moPepGen/parser/VEPParser.py
+++ b/moPepGen/parser/VEPParser.py
@@ -105,7 +105,7 @@ class VEPRecord():
     def __repr__(self)->str:
         """Return representation of the VEP record."""
         consequences = '|'.join(self.consequences)
-        return f"< {self.feature}, {consequences}, {self.location} >"
+        return f"< {self.feature}, {consequences}, {self.location}, {self.allele} >"
 
     def convert_to_variant_record(self, anno:gtf.GenomicAnnotation,
             genome:dna.DNASeqDict) -> seqvar.VariantRecord:
@@ -174,18 +174,17 @@ class VEPRecord():
                     # Sometimes insertions are reported by VEP in the end-inclusion
                     # way (e.g., C -> TACC), which needs to be converted into
                     # start-inclusion (A -> ATAC) for variants on + strand genes.
-                    if strand == 1:
-                        if seq.seq[alt_start] != allele[-1]:
-                            raise ValueError(f"Don't know how to process this variant: {self}")
+                    ref = str(seq.seq[alt_start])
+                    if ref == allele[-1]:
                         alt_start -= 1
                         alt_end = alt_start + 1
                         ref = str(seq.seq[alt_start])
                         alt = ref + allele[:-1]
-                    else:
-                        if seq.seq[alt_start] != allele[0]:
-                            raise ValueError(f"Don't know how to process this variant: {self}")
-                        ref = str(seq.seq[alt_start])
+                    elif ref == allele[0]:
+                        ref = str(ref)
                         alt = allele
+                    else:
+                        raise ValueError(f"Don't know how to process this variant: {self}")
                 else: # SNV
                     ref = str(seq.seq[alt_start])
                     alt = allele

--- a/test/unit/test_vep_parser.py
+++ b/test/unit/test_vep_parser.py
@@ -507,6 +507,34 @@ class TestVEPRecord(unittest.TestCase):
         record = vep_record.convert_to_variant_record(anno, genome)
         self.assertEqual(record.ref, 'G')
         self.assertEqual(record.alt, 'GTCA')
+    
+    def test_vep_to_variant_record_case17_insertion_start_inclusion(self):
+        """ Insertion when the location is a single spot.
+        In this test case, the variant is represented by VEP in a start-inclusion
+        format as C -> CTCA
+        """
+        genome = create_dna_record_dict(GENOME_DATA)
+        anno = create_genomic_annotation(ANNOTATION_DATA)
+
+        vep_record = VEPParser.VEPRecord(
+            uploaded_variation='rs55971985',
+            location='chr1:18',
+            allele='CTCA',
+            gene='ENSG0001',
+            feature='ENST0001.1',
+            feature_type='Transcript',
+            consequences=['missense_variant'],
+            cdna_position='11',
+            cds_position='11',
+            protein_position=3,
+            amino_acids=('S', 'T'),
+            codons=('aTa', 'aCa'),
+            existing_variation='-',
+            extra={}
+        )
+        record = vep_record.convert_to_variant_record(anno, genome)
+        self.assertEqual(record.ref, 'C')
+        self.assertEqual(record.alt, 'CTCA')
 
     def test_vep_to_variant_mnv(self):
         """ error is raised for MNV """

--- a/test/unit/test_vep_parser.py
+++ b/test/unit/test_vep_parser.py
@@ -507,7 +507,7 @@ class TestVEPRecord(unittest.TestCase):
         record = vep_record.convert_to_variant_record(anno, genome)
         self.assertEqual(record.ref, 'G')
         self.assertEqual(record.alt, 'GTCA')
-    
+
     def test_vep_to_variant_record_case17_insertion_start_inclusion(self):
         """ Insertion when the location is a single spot.
         In this test case, the variant is represented by VEP in a start-inclusion


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

We are now checking whether the first or the last nucleotide matches with the reference position for any insertion

Closes #840   <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
