### PR TITLE
Add --timeout-second and retry to callVariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Added `--graph-output-dir` to save graph data in json.
 
+- Added `--timeout-seconds` to callVariant.
+
 ## Fixed
 
 - Fixed `summarizeFasta` that SEC and W2F on fusion peptides are ignored. #789

--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -81,7 +81,8 @@ def add_subparser_call_variant(subparsers:argparse._SubParsersAction):
         ' when there are local regions that are heavily mutated. When creating'
         ' the cleavage graph, nodes containing variants larger than this value'
         ' are skipped. Setting to -1 will avoid checking for this.',
-        default=7,
+        default=(7,),
+        nargs='+',
         metavar='<number>'
     )
     p.add_argument(
@@ -90,7 +91,8 @@ def add_subparser_call_variant(subparsers:argparse._SubParsersAction):
         help='Additional variants allowed for every miscleavage. This argument'
         ' is used together with --max-variants-per-node to handle hypermutated'
         ' regions. Setting to -1 will avoid checking for this.',
-        default=2,
+        default=(2,),
+        nargs='+',
         metavar='<number>'
     )
     p.add_argument(
@@ -113,6 +115,12 @@ def add_subparser_call_variant(subparsers:argparse._SubParsersAction):
         action='store_true',
         help='Process only noncanonical transcripts of fusion transcripts and'
         ' circRNA. Canonical transcripts are skipped.'
+    )
+    p.add_argument(
+        '--timeout-seconds',
+        type=int,
+        default=1800,
+        help='Time out in seconds for each transcript.'
     )
     p.add_argument(
         '--verbose-level',
@@ -167,8 +175,8 @@ class VariantPeptideCaller():
             min_mw=float(args.min_mw),
             min_length=args.min_length,
             max_length=args.max_length,
-            max_variants_per_node = args.max_variants_per_node,
-            additional_variants_per_misc = args.additional_variants_per_misc,
+            max_variants_per_node = args.max_variants_per_node[0],
+            additional_variants_per_misc = args.additional_variants_per_misc[0],
             min_nodes_to_collapse = args.min_nodes_to_collapse,
             naa_to_collapse = args.naa_to_collapse
         )
@@ -272,6 +280,7 @@ TypePGraphs = Tuple[
     Dict[str, svgraph.PeptideVariantGraph],
     Dict[str, svgraph.PeptideVariantGraph]
 ]
+@common.timeout()
 def call_variant_peptides_wrapper(tx_id:str,
         variant_series:seqvar.TranscriptionalVariantSeries,
         tx_seqs:Dict[str, dna.DNASeqRecordWithCoordinates],
@@ -283,7 +292,8 @@ def call_variant_peptides_wrapper(tx_id:str,
         max_adjacent_as_mnv:bool,
         truncate_sec:bool,
         w2f_reassignment:bool,
-        save_graph:bool
+        save_graph:bool,
+        timeout:int=None
         ) -> Tuple[Set[aa.AminoAcidSeqRecord], str, TypeDGraphs, TypePGraphs]:
     """ wrapper function to call variant peptides """
     peptide_pool:List[Set[aa.AminoAcidSeqRecord]] = []
@@ -375,9 +385,32 @@ def call_variant_peptides_wrapper(tx_id:str,
 
     return peptide_pool, tx_id, dgraphs, pgraphs
 
-def wrapper(dispatch):
+def wrapper(dispatch, max_variants_per_node, additional_variants_per_misc):
     """ wrapper for ParallelPool """
-    return call_variant_peptides_wrapper(**dispatch)
+    tx_id = dispatch['tx_id']
+    while True:
+        try:
+            return call_variant_peptides_wrapper(**dispatch)
+        except TimeoutError:
+            new_dispatch = copy.copy(dispatch)
+            p = copy.copy(new_dispatch['cleavage_params'])
+            max_variants_per_node = max_variants_per_node[1:]
+            if len(max_variants_per_node) == 0:
+                max_variants_per_node = (p.max_variants_per_node - 1, )
+                if max_variants_per_node[0] <= 0:
+                    raise ValueError(f"Failed to finish transcript: {tx_id}")
+            additional_variants_per_misc = additional_variants_per_misc[1:]
+            if len(additional_variants_per_misc) == 0:
+                additional_variants_per_misc = (0,)
+            p.max_variants_per_node = max_variants_per_node[0]
+            p.additional_variants_per_misc = additional_variants_per_misc[0]
+            new_dispatch['cleavage_params'] = p
+            dispatch = new_dispatch
+            logger(
+                f"Transcript {tx_id} timed out. Retry with "
+                f"--max-variants-per-node {p.max_variants_per_node} "
+                f"--additional-variants-per-misc {p.additional_variants_per_misc}"
+            )
 
 def call_variant_peptide(args:argparse.Namespace) -> None:
     """ Main entry point for calling variant peptide """
@@ -475,7 +508,8 @@ def call_variant_peptide(args:argparse.Namespace) -> None:
                 'max_adjacent_as_mnv': caller.max_adjacent_as_mnv,
                 'truncate_sec': caller.truncate_sec,
                 'w2f_reassignment': caller.w2f_reassignment,
-                'save_graph': caller.graph_output_dir is not None
+                'save_graph': caller.graph_output_dir is not None,
+                'timeout': args.timeout_seconds
             }
             dispatches.append(dispatch)
 
@@ -485,9 +519,20 @@ def call_variant_peptide(args:argparse.Namespace) -> None:
                 if caller.verbose >= 2:
                     logger([x['tx_id'] for x in dispatches])
                 if caller.threads > 1:
-                    results = process_pool.map(wrapper, dispatches)
+                    results = process_pool.map(
+                        wrapper,
+                        dispatches,
+                        tuple(args.max_variants_per_node),
+                        tuple(args.additional_variants_per_misc)
+                    )
                 else:
-                    results = [wrapper(dispatches[0])]
+                    results = [
+                        wrapper(
+                            dispatches[0],
+                            tuple(args.max_variants_per_node),
+                            tuple(args.additional_variants_per_misc)
+                        )
+                    ]
 
                 # pylint: disable=W0621
                 for peptide_series, tx_id, dgraphs, pgraphs in results:

--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -394,14 +394,14 @@ def caller_reducer(dispatch):
     while True:
         try:
             return call_variant_peptides_wrapper(**dispatch)
-        except TimeoutError:
+        except TimeoutError as e:
             new_dispatch = copy.copy(dispatch)
             p = copy.copy(new_dispatch['cleavage_params'])
             max_variants_per_node = max_variants_per_node[1:]
             if len(max_variants_per_node) == 0:
                 max_variants_per_node = (p.max_variants_per_node - 1, )
                 if max_variants_per_node[0] <= 0:
-                    raise ValueError(f"Failed to finish transcript: {tx_id}")
+                    raise ValueError(f"Failed to finish transcript: {tx_id}") from e
             additional_variants_per_misc = additional_variants_per_misc[1:]
             if len(additional_variants_per_misc) == 0:
                 additional_variants_per_misc = (0,)

--- a/moPepGen/cli/common.py
+++ b/moPepGen/cli/common.py
@@ -377,6 +377,7 @@ def validate_file_format(file:Path, types:List[str]=None, check_readable:bool=Fa
 
 
 def timeout(seconds=10, error_message=os.strerror(errno.ETIME)):
+    """ Decorator to raise a TimeoutError if the process runs over time. """
     def decorator(func):
         def _handle_timeout(signum, frame):
             raise TimeoutError(error_message)

--- a/moPepGen/cli/common.py
+++ b/moPepGen/cli/common.py
@@ -375,7 +375,7 @@ def validate_file_format(file:Path, types:List[str]=None, check_readable:bool=Fa
             if not os.access(file.parent, os.W_OK):
                 raise PermissionError(f"Permission denied: '{file}'")
 
-
+# pylint: disable=unused-argument
 def timeout(seconds=10, error_message=os.strerror(errno.ETIME)):
     """ Decorator to raise a TimeoutError if the process runs over time. """
     def decorator(func):

--- a/test/integration/test_call_variant_peptides.py
+++ b/test/integration/test_call_variant_peptides.py
@@ -25,8 +25,8 @@ def create_base_args() -> argparse.Namespace:
     args.max_adjacent_as_mnv = 0
     args.selenocysteine_termination = False
     args.w2f_reassignment = False
-    args.max_variants_per_node = 7
-    args.additional_variants_per_misc = 2
+    args.max_variants_per_node = [7]
+    args.additional_variants_per_misc = [2]
     args.min_nodes_to_collapse = 30
     args.naa_to_collapse = 5
     args.inclusion_biotypes = None
@@ -42,6 +42,7 @@ def create_base_args() -> argparse.Namespace:
     args.noncanonical_transcripts = False
     args.invalid_protein_as_noncoding = False
     args.threads = 1
+    args.timeout_seconds = 1800
     return args
 
 class TestCallVariantPeptides(TestCaseIntegration):


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

I have a transcript with 375 SNV/Indels and can not finish in hours. The limiting step is calling mislceaved peptides from the PCG, after cleavage. Setting a global `max_variants_per_node` doesn't make a lot sense to me, so I implemented a timeout function. So for each transcript, if it can't be finished in certain time, it will stop and retry with a lower `max_variants_per_node` (and `additional_variants_per_misc`). 

The `--timeout-seconds` is added to callVariant and defaults to 30 minutes.

The `--max-variants-per-node` and `--additional-variants-per-misc` can accept multiple values now, and they will be used as the "retry strategy". And if we run out of the `--max-variants-per-node` values, it will continue retry with the previous value minus 1 until 0 and raise an error. For example, with `--max-variants-per-node 7 5`, the retries will be 7 -> 5 -> 4 -> 3 -> 2 -> 1 -> error (which should never happen).

`--additional-variants-per-misc` is slightly different. If we run out of values, 0 will be used. So by default it will be 2 -> 0

Closes #...  <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
