### PR TITLE
fix (mergeFasta): remove redundant FASTA header entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fixed `callVariant` of 'no reference out node found'. #842
 
+- Fixed `mergeFasta` to remove redundant FASTA header entries. #846
+
 ## [1.2.1] - 2023-10-05
 
 ### Add

--- a/moPepGen/aa/VariantPeptidePool.py
+++ b/moPepGen/aa/VariantPeptidePool.py
@@ -51,6 +51,20 @@ class VariantPeptidePool():
             same_peptide.name = same_peptide.description
         else:
             self.peptides.add(peptide)
+    
+    def remove_redundant_headers(self):
+        """ remove redundant fasta header entries """
+        for peptide in self.peptides:
+            entries = {}
+            for entry in peptide.description.split(self.peptide_delimeter):
+                unversioned = entry.rsplit('|', 1)[0]
+                if unversioned in entries:
+                    continue
+                entries[unversioned] = entry
+            header = self.peptide_delimeter.join(entries.values())
+            peptide.description = header
+            peptide.id = header
+            peptide.name = header
 
     def write(self, path:Path):
         """ Write the variant peptide pool to FASTA file.

--- a/moPepGen/aa/VariantPeptidePool.py
+++ b/moPepGen/aa/VariantPeptidePool.py
@@ -51,7 +51,7 @@ class VariantPeptidePool():
             same_peptide.name = same_peptide.description
         else:
             self.peptides.add(peptide)
-    
+
     def remove_redundant_headers(self):
         """ remove redundant fasta header entries """
         for peptide in self.peptides:

--- a/moPepGen/cli/merge_fasta.py
+++ b/moPepGen/cli/merge_fasta.py
@@ -26,6 +26,11 @@ def add_subparser_merge_fasta(subparsers:argparse._SubParsersAction):
     common.add_args_output_path(
         parser=parser, formats=OUTPUT_FILE_FORMATS
     )
+    parser.add_argument(
+        '--dedup-header',
+        action='store_true',
+        help='Remove duplicate FASTA header entries after merging.'
+    )
     common.add_args_quiet(parser)
     parser.set_defaults(func=merge_fasta)
     common.print_help_if_missing_args(parser)
@@ -60,7 +65,8 @@ def merge_fasta(args:argparse.Namespace):
             if not args.quiet:
                 logger(f"Database FASTA file loaded: {file}")
 
-    pool.remove_redundant_headers()
+    if args.dedup_header:
+        pool.remove_redundant_headers()
     pool.write(output_file)
 
     if not args.quiet:

--- a/moPepGen/cli/merge_fasta.py
+++ b/moPepGen/cli/merge_fasta.py
@@ -60,6 +60,7 @@ def merge_fasta(args:argparse.Namespace):
             if not args.quiet:
                 logger(f"Database FASTA file loaded: {file}")
 
+    pool.remove_redundant_headers()
     pool.write(output_file)
 
     if not args.quiet:

--- a/test/integration/test_merge_fasta.py
+++ b/test/integration/test_merge_fasta.py
@@ -116,3 +116,8 @@ class TestMergeFasta(TestCaseIntegration):
         with open(args.output_path, 'rt') as handle:
             pool = VariantPeptidePool.load(handle)
         self.assertEqual(len(pool.peptides), 2)
+        # redundant fasta header entries are removed
+        self.assertEqual(
+            {x.description for x in pool.peptides},
+            {'ENST0001|SNV-1-A-T|1', 'ENST0002|SNV-2-A-T|1'}
+        )

--- a/test/integration/test_merge_fasta.py
+++ b/test/integration/test_merge_fasta.py
@@ -25,6 +25,7 @@ class TestMergeFasta(TestCaseIntegration):
         """ Create base args """
         args = argparse.Namespace()
         args.output_path = self.work_dir/"output.fasta"
+        args.dedup_header = False
         args.quiet = False
         return args
 
@@ -108,6 +109,7 @@ class TestMergeFasta(TestCaseIntegration):
             self.work_dir/filename1,
             self.work_dir/filename2
         ]
+        args.dedup_header = True
 
         cli.merge_fasta(args)
 


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

Closes #846   <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
