### PR TITLE
Fix UTR in ENSEMBL style GTF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fixed `mergeFasta` to remove redundant FASTA header entries. #846
 
+- Fixed `GenomicAnnotation` to parse ENSEMBL style UTR correctly. #687
+
 ## [1.2.1] - 2023-10-05
 
 ### Add

--- a/moPepGen/gtf/TranscriptAnnotationModel.py
+++ b/moPepGen/gtf/TranscriptAnnotationModel.py
@@ -9,8 +9,17 @@ from moPepGen import dna, ERROR_INDEX_IN_INTRON
 if TYPE_CHECKING:
     from Bio.Seq import Seq
 
-GTF_FEATURE_TYPES = ['transcript', 'cds', 'exon', 'start_codon', 'stop_codon',
-    'utr', 'selenocysteine']
+GTF_FEATURE_TYPES = {
+    'transcript': 'transcript',
+    'cds': 'cds',
+    'exon': 'exon',
+    'start_codon': 'start_codon',
+    'stop_codon': 'stop_codon',
+    'utr': 'utr',
+    'selenocysteine': 'selenocysteine',
+    'five_prime_utr': 'five_utr',
+    'three_prime_utr': 'three_utr'
+}
 
 class TranscriptAnnotationModel():
     """ A TranscriptAnnotationModel holds all the annotations associated with
@@ -70,7 +79,8 @@ class TranscriptAnnotationModel():
             record (GTFRecord): The GTF record to be added.
         """
         if _type not in GTF_FEATURE_TYPES:
-            raise ValueError(f'Type must be from {GTF_FEATURE_TYPES}')
+            raise ValueError(f'Type must be from {list(GTF_FEATURE_TYPES.keys())}')
+        attr = GTF_FEATURE_TYPES[_type]
 
         for key in ['transcript_id', 'gene_id', 'protein_id', 'gene_name', 'gene_type']:
             if hasattr(record, key):
@@ -87,9 +97,9 @@ class TranscriptAnnotationModel():
                 is_protein_coding = record.attributes.pop('is_protein_coding')
                 self.is_protein_coding = is_protein_coding == 'true'
         else:
-            if self.__getattribute__(_type) is None:
-                self.__setattr__(_type, [])
-            self.__getattribute__(_type).append(record)
+            if self.__getattribute__(attr) is None:
+                self.__setattr__(attr, [])
+            self.__getattribute__(attr).append(record)
 
     def split_utr(self) -> None:
         """ Infer 3'UTR or 5'UTR. CDS must be already sorted. """

--- a/test/unit/test_gtf.py
+++ b/test/unit/test_gtf.py
@@ -210,6 +210,25 @@ class TestGTF(unittest.TestCase):
             for exon in val.exon:
                 self.assertEqual(exon.transcript_id, key)
 
+    def test_dump_gtf_ensembl_utr(self):
+        """ Test  """
+        gtf_data = (
+            '1\thavana\tgene\t100\t110\t.\t+\t.\t'
+            + 'gene_id "ENSG0001.1"; gene_name "DDX11L1";\n'
+            + '1\thavana\tfive_prime_utr\t100\t110\t.\t+\t.\t'
+            + 'gene_id "ENSG0001.1"; transcript_id "ENST0001.1"; gene_name "DDX11L1";\n'
+            + '1\thavana\tthree_prime_utr\t200\t210\t.\t+\t.\t'
+            + 'gene_id "ENSG0001.1"; transcript_id "ENST0001.1"; gene_name "DDX11L1";\n'
+        )
+        anno = gtf.GenomicAnnotation()
+        with io.BytesIO(gtf_data.encode('utf8')) as binary_file:
+            with io.TextIOWrapper(binary_file, encoding='utf8') as handle:
+                anno.dump_gtf(handle)
+        self.assertEqual(len(anno.transcripts['ENST0001.1'].five_utr), 1)
+        self.assertEqual(anno.transcripts['ENST0001.1'].five_utr[0].location.start, 99)
+        self.assertEqual(len(anno.transcripts['ENST0001.1'].three_utr), 1)
+        self.assertEqual(anno.transcripts['ENST0001.1'].three_utr[0].location.start, 199)
+
     def test_variant_coordinates_convert_case1(self):
         """ Test the converting the coordinates of variants to gene """
         attributes = {


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

This is a small PR. In GENCODE GTF, 5' and 3' UTRs are all labeled as "UTR", so we need to differentiate them. But for ENSEMBL, they are labeled as 'five_prime_utr' and 'three_prime_utr' explicitely, so we don't need to split.

Closes #687  <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
