### PR TITLE
Add basic summary to callVariant output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-## [1.3.0] - 2024-2-29
+## [1.3.0] - 2024-3-1
 
 ### Fixed:
 
@@ -31,6 +31,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed `GenomicAnnotation` to parse ENSEMBL style UTR correctly. #687
 
 - Switch to use python's `logging` package for logging.
+
+- Print basic summary to `callVariant` output. #412
 
 ## Add
 

--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -456,6 +456,8 @@ def call_variant_peptide(args:argparse.Namespace) -> None:
         if caller.threads > 1:
             process_pool = ParallelPool(ncpus=caller.threads)
 
+        logger.info('Start calling variant peptides..')
+
         dispatches = []
         i = 0
         for tx_id in tx_sorted:

--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -139,6 +139,27 @@ def add_subparser_call_variant(subparsers:argparse._SubParsersAction):
     return p
 
 
+class TallyTable:
+    """ Tally table for callVariant """
+    def __init__(self, logger:Logger):
+        """ constructor """
+        self.n_transcripts_total = 0
+        self.n_transcripts_processed = 0
+        self.n_total_peptides = 0
+        self.n_valid_peptides = 0
+        self.logger = logger
+
+    def log(self):
+        """ log """
+        self.logger.info("callVariant summary:")
+        self.logger.info("Total transcripts with variants: %i", self.n_transcripts_total)
+        self.logger.info("Total transcripts processed: %i", self.n_transcripts_processed)
+        self.logger.info(
+            "Total variant peptides generated (including redundant): %i",
+            self.n_total_peptides
+        )
+        self.logger.info("Total variant peptides saved: %i", self.n_valid_peptides)
+
 class VariantPeptideCaller():
     """ Helper class to call variant peptides """
     def __init__(self, args:argparse.Namespace):
@@ -193,6 +214,7 @@ class VariantPeptideCaller():
             self.check_external_variants = True
 
         self.logger:Logger = None
+        self.tally:TallyTable = None
 
     def load_reference(self):
         """ load reference genome, annotation, and canonical peptides """
@@ -418,6 +440,7 @@ def call_variant_peptide(args:argparse.Namespace) -> None:
     ref = caller.reference_data
     logger = get_logger()
     caller.logger = logger
+    caller.tally = TallyTable(logger)
 
     with seqvar.VariantRecordPoolOnDiskOpener(caller.variant_record_pool) as pool:
         for file in pool.gvf_files:
@@ -425,6 +448,7 @@ def call_variant_peptide(args:argparse.Namespace) -> None:
         tx_rank = ref.anno.get_transcript_rank()
         tx_sorted = sorted(pool.pointers.keys(), key=lambda x:tx_rank[x])
         logger.info('Variants sorted')
+        caller.tally.n_transcripts_total = len(tx_sorted)
 
         # Not providing canonical peptide pool to each task for now.
         canonical_peptides = set()
@@ -511,6 +535,8 @@ def call_variant_peptide(args:argparse.Namespace) -> None:
             }
             dispatches.append(dispatch)
 
+            caller.tally.n_transcripts_processed += 1
+
             reloaded = ((i + 1) % caller.threads == 0 or i + 1 == len(tx_sorted)) \
                 and len(dispatches) > 0
             if reloaded:
@@ -526,6 +552,7 @@ def call_variant_peptide(args:argparse.Namespace) -> None:
                 # pylint: disable=W0621
                 for peptide_series, tx_id, dgraphs, pgraphs in results:
                     for peptides in peptide_series:
+                        caller.tally.n_total_peptides += len(peptides)
                         for peptide in peptides:
                             caller.variant_peptides.add_peptide(
                                 peptide=peptide,
@@ -539,10 +566,13 @@ def call_variant_peptide(args:argparse.Namespace) -> None:
 
             i += 1
             if i % 1000 == 0:
-                logger.info('%i transcripts processed.', i)
-
+                logger.info(
+                    '%.2f %% ( %i / %i ) transcripts processed.',
+                    i/len(tx_sorted) * 100, i, len(tx_sorted)
+                )
+    caller.tally.n_valid_peptides = len(caller.variant_peptides.peptides)
+    caller.tally.log()
     caller.write_fasta()
-
 
 def call_canonical_peptides(tx_id:str, ref:params.ReferenceData,
         tx_seq:dna.DNASeqRecordWithCoordinates,


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

Add some basic summary to `callVariant` output. Looks like this now:

```
python -m moPepGen.cli callVariant -i test/files/vep/vep_gSNP.gvf test/files/vep/vep_gINDEL.gvf test/files/fusion/star_fusion.gvf --index-dir test/files/index -o test/files/vep/test3.fasta
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] moPepGen callVariant started
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] Reference indices loaded.
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] Using GVF file: test/files/vep/vep_gSNP.gvf
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] Using GVF file: test/files/vep/vep_gINDEL.gvf
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] Using GVF file: test/files/fusion/star_fusion.gvf
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] Variants sorted
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] Start calling variant peptides..
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] callVariant summary:
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] Total transcripts with variants: 5
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] Total transcripts processed: 5
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] Total variant peptides generated (including redundant): 57
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] Total variant peptides saved: 28
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] Variant peptide FASTA file written to disk.
[ 2024-03-01 11:05:00 ] [ moPepGen -  INFO ] rss=79.71 MiB, vms=395.6 MiB, wallclock=0:00:01.330000, system=0:00:00.670000, cpu_usage=100.4%
```

Closes #412  <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
