### PR TITLE
Peptide Table saved by callVariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Added `updateIndex` #853
 
+- Output a peptide table for additional information. #833
+
 ## [1.2.1] - 2023-10-05
 
 ### Add

--- a/moPepGen/SeqFeature.py
+++ b/moPepGen/SeqFeature.py
@@ -76,6 +76,18 @@ class FeatureLocation(BioFeatureLocation):
         """ Find whether the location is a superset of the other """
         return self.start <= other.start and self.end >= other.end
 
+    def shift(self, i:int) -> FeatureLocation:
+        """ shift """
+        return FeatureLocation(
+            seqname=self.seqname,
+            start=self.start + i,
+            end=self.end + i,
+            reading_frame_index=self.reading_frame_index,
+            start_offset=self.start_offset,
+            end_offset=self.end_offset,
+            strand=self.strand
+        )
+
 
 class SeqFeature(BioSeqFeature):
     """ Models the annotation of a given range of the sequence. This extends

--- a/moPepGen/aa/VariantPeptidePool.py
+++ b/moPepGen/aa/VariantPeptidePool.py
@@ -22,7 +22,7 @@ class VariantPeptidePool():
 
     def add_peptide(self, peptide:AminoAcidSeqRecord,
             canonical_peptides:Set[str], cleavage_params:params.CleavageParams=None,
-            skip_checking:bool=False):
+            skip_checking:bool=False) -> bool:
         """ Add a peptide to the pool if it does not already exist. Otherwise,
         the label is appended to the existing same peptide.
 
@@ -36,12 +36,12 @@ class VariantPeptidePool():
             min_mw = cleavage_params.min_mw
             min_length = cleavage_params.min_length
             max_length = cleavage_params.max_length
-            if SeqUtils.molecular_weight(peptide.seq, 'protein') < min_mw:
-                return
-            if len(peptide.seq) < min_length or len(peptide.seq) > max_length:
-                return
+            if SeqUtils.molecular_weight(peptide, 'protein') < min_mw:
+                return False
+            if len(peptide.seq) < min_length or len(peptide) > max_length:
+                return False
             if str(peptide.seq) in canonical_peptides:
-                return
+                return False
         same_peptide = get_equivalent(self.peptides, peptide)
         if same_peptide:
             same_peptide:Seq
@@ -51,6 +51,7 @@ class VariantPeptidePool():
             same_peptide.name = same_peptide.description
         else:
             self.peptides.add(peptide)
+        return True
 
     def remove_redundant_headers(self):
         """ remove redundant fasta header entries """

--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -592,9 +592,12 @@ def call_variant_peptide(args:argparse.Namespace) -> None:
                     '%.2f %% ( %i / %i ) transcripts processed.',
                     i/len(tx_sorted) * 100, i, len(tx_sorted)
                 )
+        logger.info('All transcripts processed. Preparing FASTA file..')
+        peptide_table.write_fasta(caller.output_path)
+        logger.info('Variant peptide FASTA written.')
+
         caller.tally.n_valid_peptides = len(peptide_table.index)
         caller.tally.log()
-        peptide_table.write_fasta(caller.output_path)
 
 def call_canonical_peptides(tx_id:str, ref:params.ReferenceData,
         tx_seq:dna.DNASeqRecordWithCoordinates,

--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -317,14 +317,14 @@ def call_variant_peptides_wrapper(tx_id:str,
         ) -> Tuple[Dict[Seq, List[AnnotatedPeptideLabel]], str, TypeDGraphs, TypePGraphs]:
     """ wrapper function to call variant peptides """
     logger = get_logger()
-    peptide_anno:Dict[Seq, List[AnnotatedPeptideLabel]] = {}
+    peptide_anno:Dict[Seq, Dict[str, AnnotatedPeptideLabel]] = {}
 
     def add_peptide_anno(x:Dict[Seq, List[AnnotatedPeptideLabel]]):
-        for k,v in x.items():
-            if k in peptide_anno:
-                peptide_anno[k] += v
-            else:
-                peptide_anno[k] = v
+        for seq, seq_data in x.items():
+            val = peptide_anno.setdefault(seq, {})
+            for metadata in seq_data:
+                if metadata.label not in val:
+                    val[metadata.label] = metadata
 
     main_peptides = None
     denylist = call_canonical_peptides(
@@ -408,6 +408,8 @@ def call_variant_peptides_wrapper(tx_id:str,
         dgraphs[2][circ_model.id] = cgraph
         pgraphs[2][circ_model.id] = pgraph
         add_peptide_anno(peptide_map)
+
+    peptide_anno = {k:list(v.values()) for k,v in peptide_anno.items()}
 
     return peptide_anno, tx_id, dgraphs, pgraphs
 

--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -592,11 +592,10 @@ def call_variant_peptide(args:argparse.Namespace) -> None:
                     '%.2f %% ( %i / %i ) transcripts processed.',
                     i/len(tx_sorted) * 100, i, len(tx_sorted)
                 )
+        caller.tally.n_valid_peptides = len(peptide_table.index)
         logger.info('All transcripts processed. Preparing FASTA file..')
         peptide_table.write_fasta(caller.output_path)
         logger.info('Variant peptide FASTA written.')
-
-        caller.tally.n_valid_peptides = len(peptide_table.index)
         caller.tally.log()
 
 def call_canonical_peptides(tx_id:str, ref:params.ReferenceData,

--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -688,7 +688,7 @@ def call_peptide_fusion(variant:seqvar.VariantRecord,
 
     orf_start = tx_seq.orf.start + 3 if tx_seq.orf else 3
     if variant.location.start < orf_start:
-        return [], None, None
+        return {}, None, None
 
     if tx_id in variant_pool:
         tx_variants = [x for x in variant_pool[tx_id].transcriptional
@@ -758,7 +758,7 @@ def call_peptide_circ_rna(record:circ.CircRNAModel,
         fragments.append(frag)
 
     if not fragments:
-        return set(), None, None
+        return {}, None, None
 
     variant_records = variant_pool.filter_variants(
         tx_ids=[record.transcript_id], exclude_type=exclusion_variant_types,

--- a/moPepGen/svgraph/PeptideVariantGraph.py
+++ b/moPepGen/svgraph/PeptideVariantGraph.py
@@ -1,7 +1,7 @@
 """ Module for peptide variation graph """
 from __future__ import annotations
 import copy
-from typing import Callable, FrozenSet, Iterable, Set, Deque, Dict, List, Tuple
+from typing import Callable, FrozenSet, Iterable, Set, Deque, Dict, List, Tuple, TYPE_CHECKING
 from collections import deque
 from functools import cmp_to_key
 from Bio.Seq import Seq
@@ -13,6 +13,9 @@ from moPepGen.svgraph.PVGNode import PVGNode
 from moPepGen.svgraph.PVGOrf import PVGOrf
 from moPepGen.svgraph.PVGNodeCollapser import PVGNodeCollapser, PVGNodePopCollapser
 
+
+if TYPE_CHECKING:
+    from .VariantPeptideDict import AnnotatedPeptideLabel
 
 T = Tuple[Set[PVGNode],Dict[PVGNode,List[PVGNode]]]
 
@@ -790,7 +793,7 @@ class PeptideVariantGraph():
             check_orf:bool=False, keep_all_occurrence:bool=True, denylist:Set[str]=None,
             circ_rna:circ.CircRNAModel=None, orf_assignment:str='max',
             truncate_sec:bool=False, w2f:bool=False, check_external_variants:bool=True
-            ) -> Set[aa.AminoAcidSeqRecord]:
+            ) -> Dict[Seq, List[AnnotatedPeptideLabel]]:
         """ Walk through the graph and find all variated peptides.
 
         Args:

--- a/moPepGen/svgraph/PeptideVariantGraph.py
+++ b/moPepGen/svgraph/PeptideVariantGraph.py
@@ -822,7 +822,8 @@ class PeptideVariantGraph():
             truncate_sec=truncate_sec,
             w2f=w2f,
             check_external_variants=check_external_variants,
-            cleavage_params=self.cleavage_params
+            cleavage_params=self.cleavage_params,
+            check_orf=check_orf
         )
         traversal = PVGTraversal(
             check_variants=check_external_variants,

--- a/moPepGen/svgraph/SubgraphTree.py
+++ b/moPepGen/svgraph/SubgraphTree.py
@@ -11,13 +11,15 @@ if TYPE_CHECKING:
 class SubgraphBranch():
     """ ParentGraphLocation """
     def __init__(self, _id:str, level:int, parent_id:str,  location:FeatureLocation,
-            variant:VariantRecord):
+            variant:VariantRecord, feature_type:str, feature_id:str):
         """ constructur """
         self.id = _id
         self.level = level
         self.parent_id = parent_id
         self.location = location
         self.variant = variant
+        self.feature_type = feature_type
+        self.feature_id= feature_id
 
     def is_parent(self, other:SubgraphBranch) -> bool:
         """ Checks if it is the parent of a given subgraph """
@@ -36,23 +38,26 @@ class SubgraphTree():
         """ Get item """
         return self.data[key]
 
-    def add_root(self, _id:str):
+    def add_root(self, _id:str, feature_type:str, feature_id:str, variant:VariantRecord):
         """ Add the main graph """
         subgraph = SubgraphBranch(
-            _id=_id, level=0, parent_id=None, location=None, variant=None
+            _id=_id, level=0, parent_id=None, location=None, variant=variant,
+            feature_type=feature_type, feature_id=feature_id
         )
         self.data[_id] = subgraph
         self.root = subgraph
 
     def add_subgraph(self, child_id:str, parent_id:str, level:int,
-            start:int, end:int, variant:VariantRecord):
+            start:int, end:int, variant:VariantRecord,
+            feature_type:str, feature_id:str):
         """ Add subgraph """
         location = FeatureLocation(
             seqname=parent_id, start=start, end=end
         )
         subgraph = SubgraphBranch(
             _id=child_id, level=level, parent_id=parent_id,
-            location=location, variant=variant
+            location=location, variant=variant,
+            feature_type=feature_type, feature_id=feature_id
         )
         self.data[child_id] = subgraph
 

--- a/moPepGen/svgraph/ThreeFrameCVG.py
+++ b/moPepGen/svgraph/ThreeFrameCVG.py
@@ -148,7 +148,8 @@ class ThreeFrameCVG(ThreeFrameTVG):
             sub_tail_nodes = sub.get_tail_nodes()
             self.subgraphs.add_subgraph(
                 child_id=sub.id, parent_id=cur.id, level=sub.root.level,
-                start=self.seq.locations[-1].ref.end, end=self.seq.locations[-1].ref.end
+                start=self.seq.locations[-1].ref.end, end=self.seq.locations[-1].ref.end,
+                variant=self.global_variant
             )
             for edge in sub.root.out_edges:
                 root = edge.out_node

--- a/moPepGen/svgraph/ThreeFrameCVG.py
+++ b/moPepGen/svgraph/ThreeFrameCVG.py
@@ -149,7 +149,7 @@ class ThreeFrameCVG(ThreeFrameTVG):
             self.subgraphs.add_subgraph(
                 child_id=sub.id, parent_id=cur.id, level=sub.root.level,
                 start=self.seq.locations[-1].ref.end, end=self.seq.locations[-1].ref.end,
-                variant=self.global_variant
+                variant=self.global_variant, feature_type='gene', feature_id=self.gene_id
             )
             for edge in sub.root.out_edges:
                 root = edge.out_node

--- a/moPepGen/svgraph/ThreeFrameTVG.py
+++ b/moPepGen/svgraph/ThreeFrameTVG.py
@@ -433,7 +433,8 @@ class ThreeFrameTVG():
             var_node.level = level
             self.subgraphs.add_subgraph(
                 child_id=subgraph_id, parent_id=self.id, level=level,
-                start=variant.location.start, end=variant.location.end
+                start=variant.location.start, end=variant.location.end,
+                variant=variant
             )
 
         returns = [None, None]
@@ -534,7 +535,8 @@ class ThreeFrameTVG():
             subgraph_end = var.variant.location.end
         self.subgraphs.add_subgraph(
             child_id=subgraph_id, parent_id=parent_id, level=level,
-            start=subgraph_start, end=subgraph_end
+            start=subgraph_start, end=subgraph_end,
+            variant=var.variant
         )
         branch.init_three_frames(truncate_head=False)
         for rf_index, root in enumerate(branch.reading_frames):
@@ -776,7 +778,8 @@ class ThreeFrameTVG():
         parent_id = cursors[0].subgraph_id
         self.subgraphs.add_subgraph(
             child_id=subgraph_id, parent_id=parent_id, level=level,
-            start=var.location.start, end=var.location.end
+            start=var.location.start, end=var.location.end,
+            variant=var.variant
         )
         branch.init_three_frames(truncate_head=False)
         for rf_index, root in enumerate(branch.reading_frames):

--- a/moPepGen/svgraph/ThreeFrameTVG.py
+++ b/moPepGen/svgraph/ThreeFrameTVG.py
@@ -42,6 +42,7 @@ class ThreeFrameTVG():
             _id:str, root:TVGNode=None, reading_frames:List[TVGNode]=None,
             cds_start_nf:bool=False, has_known_orf:bool=None,
             mrna_end_nf:bool=False, global_variant:seqvar.VariantRecord=None,
+            coordinate_feature_type:str=None, coordinate_feature_id:str=None,
             subgraphs:SubgraphTree=None, hypermutated_region_warned:bool=False,
             cleavage_params:params.CleavageParams=None, gene_id:str=None,
             sect_variants:List[seqvar.VariantRecordWithCoordinate]=None,
@@ -63,7 +64,11 @@ class ThreeFrameTVG():
         self.mrna_end_nf = mrna_end_nf
         self.global_variant = global_variant
         self.subgraphs = subgraphs or SubgraphTree()
-        self.subgraphs.add_root(_id)
+        self.subgraphs.add_root(
+            _id, variant=self.global_variant,
+            feature_type=coordinate_feature_type,
+            feature_id=coordinate_feature_id
+        )
         self.hypermutated_region_warned = hypermutated_region_warned
         self.cleavage_params = cleavage_params or params.CleavageParams('trypsin')
         self.gene_id = gene_id
@@ -434,7 +439,7 @@ class ThreeFrameTVG():
             self.subgraphs.add_subgraph(
                 child_id=subgraph_id, parent_id=self.id, level=level,
                 start=variant.location.start, end=variant.location.end,
-                variant=variant
+                variant=variant, feature_type='transcript', feature_id=self.id
             )
 
         returns = [None, None]
@@ -491,7 +496,8 @@ class ThreeFrameTVG():
             var:seqvar.VariantRecordWithCoordinate,
             seq:DNASeqRecordWithCoordinates,
             variants:List[seqvar.VariantRecord], position:int,
-            attach_directly:bool=False, known_orf_index:int=None
+            attach_directly:bool=False, known_orf_index:int=None,
+            coordinate_feature_type:str=None, coordinate_feature_id:str=None
             ) -> List[TVGNode]:
         """ Insert flanking variant node into the graph. This function is used
         in apply_fusion to insert the intronic sequences.
@@ -522,7 +528,9 @@ class ThreeFrameTVG():
             seq, subgraph_id,
             global_variant=var.variant,
             cleavage_params=self.cleavage_params,
-            max_adjacent_as_mnv=self.max_adjacent_as_mnv
+            max_adjacent_as_mnv=self.max_adjacent_as_mnv,
+            coordinate_feature_type=coordinate_feature_type,
+            coordinate_feature_id=coordinate_feature_id
         )
         level = cursors[0].level + 1
         branch.update_node_level(level)
@@ -536,7 +544,9 @@ class ThreeFrameTVG():
         self.subgraphs.add_subgraph(
             child_id=subgraph_id, parent_id=parent_id, level=level,
             start=subgraph_start, end=subgraph_end,
-            variant=var.variant
+            variant=var.variant,
+            feature_type=coordinate_feature_type,
+            feature_id=coordinate_feature_id
         )
         branch.init_three_frames(truncate_head=False)
         for rf_index, root in enumerate(branch.reading_frames):
@@ -665,7 +675,9 @@ class ThreeFrameTVG():
                 variants=insertion_variants,
                 position=variant.location.start,
                 attach_directly=False,
-                known_orf_index=known_orf_index
+                known_orf_index=known_orf_index,
+                coordinate_feature_type='gene',
+                coordinate_feature_id=gene_id
             )
 
         # create subgraph for the right insertion
@@ -705,7 +717,9 @@ class ThreeFrameTVG():
                 variants=insertion_variants,
                 position=position,
                 attach_directly=attach_directly,
-                known_orf_index=known_orf_index
+                known_orf_index=known_orf_index,
+                coordinate_feature_type='gene',
+                coordinate_feature_id=gene_id
             )
 
         breakpoint_gene = variant.get_accepter_position()
@@ -741,15 +755,17 @@ class ThreeFrameTVG():
             variants=accepter_variant_records,
             position=position,
             attach_directly=attach_directly,
-            known_orf_index=known_orf_index
+            known_orf_index=known_orf_index,
+            coordinate_feature_type='transcript',
+            coordinate_feature_id=accepter_tx_id
         )
         return original_cursors
 
     def _apply_insertion(self, cursors:List[TVGNode],
             var:seqvar.VariantRecordWithCoordinate,
             seq:dna.DNASeqRecordWithCoordinates,
-            variants:List[seqvar.VariantRecord],
-            active_frames:List[bool]
+            variants:List[seqvar.VariantRecord], active_frames:List[bool],
+            coordinate_feature_type:str, coordinate_feature_id:str
         ) -> List[TVGNode]:
         """ This is a wrapper function to apply insertions to the graph. It can
         be used for actual Insertion, and also Substitution. It is also used
@@ -771,7 +787,9 @@ class ThreeFrameTVG():
             loc.ref.seqname = subgraph_id
         branch = ThreeFrameTVG(
             seq, subgraph_id, global_variant=var.variant,
-            max_adjacent_as_mnv=self.max_adjacent_as_mnv
+            max_adjacent_as_mnv=self.max_adjacent_as_mnv,
+            coordinate_feature_type=coordinate_feature_type,
+            coordinate_feature_id=coordinate_feature_id
         )
         level = cursors[0].level + 1
         branch.update_node_level(level)
@@ -779,7 +797,9 @@ class ThreeFrameTVG():
         self.subgraphs.add_subgraph(
             child_id=subgraph_id, parent_id=parent_id, level=level,
             start=var.location.start, end=var.location.end,
-            variant=var.variant
+            variant=var.variant,
+            feature_type=coordinate_feature_type,
+            feature_id=coordinate_feature_id
         )
         branch.init_three_frames(truncate_head=False)
         for rf_index, root in enumerate(branch.reading_frames):
@@ -915,7 +935,9 @@ class ThreeFrameTVG():
             var=var,
             seq=insert_seq,
             variants=insert_variants,
-            active_frames=active_frames
+            active_frames=active_frames,
+            coordinate_feature_type='gene',
+            coordinate_feature_id=gene_id
         )
 
     def apply_substitution(self, cursors:List[TVGNode],
@@ -950,7 +972,9 @@ class ThreeFrameTVG():
             var=var,
             seq=sub_seq,
             variants=sub_variants,
-            active_frames=active_frames
+            active_frames=active_frames,
+            coordinate_feature_type='gene',
+            coordinate_feature_id=gene_id
         )
 
 

--- a/moPepGen/svgraph/VariantPeptideDict.py
+++ b/moPepGen/svgraph/VariantPeptideDict.py
@@ -7,7 +7,7 @@ from typing import Deque, Dict, Iterable, List, Set, Tuple, TYPE_CHECKING
 from Bio.Seq import Seq
 from Bio import SeqUtils
 from moPepGen import aa, circ, get_equivalent, seqvar
-from moPepGen.SeqFeature import FeatureLocation, MatchedLocation
+from moPepGen.SeqFeature import FeatureLocation
 from moPepGen.svgraph.PVGNode import PVGNode
 from moPepGen.svgraph.PVGOrf import PVGOrf
 from moPepGen.aa import VariantPeptideIdentifier as vpi

--- a/moPepGen/svgraph/VariantPeptideDict.py
+++ b/moPepGen/svgraph/VariantPeptideDict.py
@@ -68,7 +68,7 @@ class PeptideSegment:
             query=query,
             ref=ref,
             feature_type=self.feature_type,
-            feature_id=self.feature_type,
+            feature_id=self.feature_id,
             variant=self.variant
         )
 

--- a/moPepGen/svgraph/VariantPeptideDict.py
+++ b/moPepGen/svgraph/VariantPeptideDict.py
@@ -82,9 +82,9 @@ class PeptideSegment:
                 or self.feature_id != other.feature_id:
             return False
         if self.ref:
-            this = MatchedLocation(self.query, self.ref)
-            that = MatchedLocation(other.query, other.ref)
-            if this.get_ref_dna_end() != that.get_ref_dna_start():
+            this_end = self.ref.end * 3 + self.ref.end_offset - self.query.end_offset
+            that_start = other.ref.start * 3 + other.ref.start_offset + other.query.start_offset
+            if this_end != that_start:
                 return False
         return True
 

--- a/moPepGen/svgraph/VariantPeptideDict.py
+++ b/moPepGen/svgraph/VariantPeptideDict.py
@@ -39,13 +39,13 @@ class VariantPeptideMetadata():
 class PeptideSegment:
     """ Peptide segment """
     def __init__(self, query:FeatureLocation, ref:FeatureLocation, feature_type:str,
-            feature_id:str, variant:VariantRecord):
+            feature_id:str, variant_id:str):
         """ constructor """
         self.query = query
         self.ref = ref
         self.feature_type = feature_type
         self.feature_id = feature_id
-        self.variant = variant
+        self.variant_id = variant_id
 
     def merge(self, other:PeptideSegment) -> PeptideSegment:
         """ merge """
@@ -69,14 +69,14 @@ class PeptideSegment:
             ref=ref,
             feature_type=self.feature_type,
             feature_id=self.feature_id,
-            variant=self.variant
+            variant_id=self.variant_id
         )
 
     def is_adjacent(self, other:PeptideSegment) -> bool:
         """ is adjacent """
-        if (self.variant is None) != (other.variant is None) \
-                or (self.variant is not None \
-                    and self.variant.id != other.variant.id) \
+        if (self.variant_id is None) != (other.variant_id is None) \
+                or (self.variant_id is not None \
+                    and self.variant_id != other.variant_id) \
                 or self.query.end != other.query.start \
                 or self.feature_type != other.feature_type \
                 or self.feature_id != other.feature_id:
@@ -109,8 +109,8 @@ class PeptideSegment:
             str(self.query.start_offset),
             str(self.query.end_offset)
         ]
-        if self.variant:
-            fields.append(self.variant.id)
+        if self.variant_id:
+            fields.append(self.variant_id)
         else:
             fields.append('.')
         return '\t'.join(fields)
@@ -234,7 +234,7 @@ class MiscleavedNodes():
                     ref=loc.ref,
                     feature_type=branch.feature_type,
                     feature_id=branch.feature_id,
-                    variant=branch.variant
+                    variant_id=branch.variant.id if branch.variant else None
                 )
                 if ref_segments and ref_segments[-1].is_adjacent(seg):
                     ref_segments[-1] = ref_segments[-1].merge(seg)
@@ -254,7 +254,7 @@ class MiscleavedNodes():
                     ref=None,
                     feature_type=None,
                     feature_id=None,
-                    variant=variant.variant
+                    variant_id=variant.variant.id
                 )
                 if var_segments and var_segments[-1].is_adjacent(seg):
                     var_segments[-1] = var_segments[-1].merge(seg)

--- a/moPepGen/svgraph/VariantPeptideTable.py
+++ b/moPepGen/svgraph/VariantPeptideTable.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from moPepGen.params import CleavageParams
 
 VARIANT_PEPTIDE_TABLE_HEADERS = [
-    '#seq', 'label', 'start', 'end', 'feature_type', 'feature_id',
+    '#sequence', 'header', 'start', 'end', 'feature_type', 'feature_id',
     'ref_start', 'ref_end', 'start_offset', 'end_offset', 'variant'
 ]
 

--- a/moPepGen/svgraph/VariantPeptideTable.py
+++ b/moPepGen/svgraph/VariantPeptideTable.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from moPepGen.params import CleavageParams
 
 VARIANT_PEPTIDE_TABLE_HEADERS = [
-    '#sequence', 'header', 'start', 'end', 'feature_type', 'feature_id',
+    '#sequence', 'header', 'subsequence', 'start', 'end', 'feature_type', 'feature_id',
     'ref_start', 'ref_end', 'start_offset', 'end_offset', 'variant'
 ]
 
@@ -45,8 +45,10 @@ class VariantPeptideTable:
     def add_peptide(self, seq:Seq, peptide_anno:AnnotatedPeptideLabel):
         """ Write """
         start = self.handle.tell()
-        for line in peptide_anno.to_lines():
-            self.handle.write(f"{str(seq)}\t{line}\n")
+        for seg in peptide_anno.segments:
+            subseq = str(seq[seg.query.start:seg.query.end])
+            line = f"{str(seq)}\t{peptide_anno.label}\t{subseq}\t{seg.to_line()}\n"
+            self.handle.write(line)
         end = self.handle.tell()
         cur = (start, end)
         if seq in self.index:

--- a/moPepGen/svgraph/VariantPeptideTable.py
+++ b/moPepGen/svgraph/VariantPeptideTable.py
@@ -1,0 +1,85 @@
+""" Varaint Peptide Table """
+from __future__ import annotations
+from typing import TYPE_CHECKING, Dict, Set, IO, List, Tuple
+from Bio import SeqUtils
+from Bio.SeqIO import FastaIO
+from moPepGen import VARIANT_PEPTIDE_SOURCE_DELIMITER, aa
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from Bio.Seq import Seq
+    from moPepGen.svgraph.VariantPeptideDict import AnnotatedPeptideLabel
+    from moPepGen.params import CleavageParams
+
+VARIANT_PEPTIDE_TABLE_HEADERS = [
+    '#seq', 'label', 'start', 'end', 'feature_type', 'feature_id',
+    'ref_start', 'ref_end', 'start_offset', 'end_offset', 'variant'
+]
+
+class VariantPeptideTable:
+    """ Variant Peptide Segment Annotation """
+    def __init__(self, handle:IO, index:Dict[Seq, List[Tuple[int,int]]]=None):
+        self.handle = handle
+        self.index = index or {}
+        self.header_delimeter = VARIANT_PEPTIDE_SOURCE_DELIMITER
+
+    def write_header(self):
+        """ Write header """
+        self.handle.write('\t'.join(VARIANT_PEPTIDE_TABLE_HEADERS) + '\n')
+
+    def is_valid(self, seq:Seq, canonical_peptides:Set[str],
+            cleavage_params:CleavageParams=None):
+        """ Check if the peptide is valid """
+        min_mw = cleavage_params.min_mw
+        min_length = cleavage_params.min_length
+        max_length = cleavage_params.max_length
+        if SeqUtils.molecular_weight(seq, 'protein') < min_mw:
+            return False
+        if len(seq) < min_length or len(seq) > max_length:
+            return False
+        if str(seq) in canonical_peptides:
+            return False
+        return True
+
+    def add_peptide(self, seq:Seq, peptide_anno:AnnotatedPeptideLabel):
+        """ Write """
+        start = self.handle.tell()
+        for line in peptide_anno.to_lines():
+            self.handle.write(f"{str(seq)}\t{line}\n")
+        end = self.handle.tell()
+        cur = (start, end)
+        if seq in self.index:
+            self.index[seq].append(cur)
+        else:
+            self.index[seq] = [cur]
+
+    def load_pepitde(self, seq:Seq):
+        """ Load peptide from table """
+        labels = set()
+        for start, end in self.index[seq]:
+            self.handle.seek(start, 0)
+            buffer:str = self.handle.read(end - start)
+            for line in buffer.rstrip().split('\n'):
+                fields = line.split('\t')
+                if seq != fields[0]:
+                    raise ValueError(
+                        f"Peptide ({seq}) do not match with table record ({fields[0]})."
+                    )
+                labels.add(fields[1])
+        label = self.header_delimeter.join(labels)
+
+        return aa.AminoAcidSeqRecord(
+            seq=seq,
+            description=label,
+            name=label
+        )
+
+    def write_fasta(self, path:Path):
+        """ write fasta """
+        with open(path, 'wt') as handle:
+            record2title = lambda x: x.description
+            writer = FastaIO.FastaWriter(handle, record2title=record2title)
+            for seq in self.index:
+                peptide = self.load_pepitde(seq)
+                writer.write_record(peptide)

--- a/moPepGen/svgraph/__init__.py
+++ b/moPepGen/svgraph/__init__.py
@@ -6,3 +6,4 @@ from moPepGen.svgraph.TVGCursor import TVGCursor
 from moPepGen.svgraph.PeptideVariantGraph import PeptideVariantGraph
 from moPepGen.svgraph.PVGNode import PVGNode
 from moPepGen.svgraph.ThreeFrameCVG import ThreeFrameCVG
+from moPepGen.svgraph.VariantPeptideTable import VariantPeptideTable

--- a/moPepGen/util/fuzz_test.py
+++ b/moPepGen/util/fuzz_test.py
@@ -635,7 +635,7 @@ class FuzzTestCase():
         args.naa_to_collapse = 5
         args.noncanonical_transcripts = False
         args.invalid_protein_as_noncoding = False
-        args.verbose_level = 1
+        args.debug_level = 1
         call_variant_peptide(args=args)
 
     def brute_force(self):

--- a/moPepGen/util/validate_variant_calling.py
+++ b/moPepGen/util/validate_variant_calling.py
@@ -111,7 +111,7 @@ def call_variant(gvf_files:Path, ref_dir:Path, output_fasta:Path, graph_output_d
     args.output_path = output_fasta
     args.graph_output_dir = graph_output_dir
     args.quiet = False
-    args.verbose_level = 1
+    args.debug_level = 1
     args.cleavage_rule = 'trypsin'
     args.cleavage_exception = None
     args.miscleavage = 2

--- a/test/integration/test_call_variant_peptides.py
+++ b/test/integration/test_call_variant_peptides.py
@@ -39,7 +39,7 @@ def create_base_args() -> argparse.Namespace:
     args.min_length = 7
     args.max_length = 25
     args.quiet = True
-    args.verbose_level = 1
+    args.debug_level = 1
     args.noncanonical_transcripts = False
     args.invalid_protein_as_noncoding = False
     args.threads = 1

--- a/test/integration/test_call_variant_peptides.py
+++ b/test/integration/test_call_variant_peptides.py
@@ -84,7 +84,7 @@ class TestCallVariantPeptides(TestCaseIntegration):
         args.reference_source = None
         cli.call_variant_peptide(args)
         files = {str(file.name) for file in self.work_dir.glob('*')}
-        expected = {'vep_moPepGen.fasta'}
+        expected = {'vep_moPepGen.fasta', 'vep_moPepGen_peptide_table.txt'}
         self.assertEqual(files, expected)
         if not expect:
             return
@@ -127,7 +127,7 @@ class TestCallVariantPeptides(TestCaseIntegration):
         args.proteome_fasta = self.data_dir/'translate.fasta'
         cli.call_variant_peptide(args)
         files = {str(file.name) for file in self.work_dir.glob('*')}
-        expected = {'vep_moPepGen.fasta'}
+        expected = {'vep_moPepGen.fasta', 'vep_moPepGen_peptide_table.txt'}
         self.assertEqual(files, expected)
 
     def test_call_variant_peptide_case1_sect_and_w2f(self):
@@ -143,7 +143,7 @@ class TestCallVariantPeptides(TestCaseIntegration):
         args.w2f_reassignment = True
         cli.call_variant_peptide(args)
         files = {str(file.name) for file in self.work_dir.glob('*')}
-        expected = {'vep_moPepGen.fasta'}
+        expected = {'vep_moPepGen.fasta', 'vep_moPepGen_peptide_table.txt'}
         self.assertEqual(files, expected)
 
     def test_call_variant_peptide_case2(self):
@@ -159,7 +159,7 @@ class TestCallVariantPeptides(TestCaseIntegration):
         args.proteome_fasta = self.data_dir/'translate.fasta'
         cli.call_variant_peptide(args)
         files = {str(file.name) for file in self.work_dir.glob('*')}
-        expected = {'vep_moPepGen.fasta'}
+        expected = {'vep_moPepGen.fasta', 'vep_moPepGen_peptide_table.txt'}
         self.assertEqual(files, expected)
 
     def test_call_variant_peptide_case3(self):
@@ -176,7 +176,7 @@ class TestCallVariantPeptides(TestCaseIntegration):
         args.proteome_fasta = self.data_dir/'translate.fasta'
         cli.call_variant_peptide(args)
         files = {str(file.name) for file in self.work_dir.glob('*')}
-        expected = {'vep_moPepGen.fasta'}
+        expected = {'vep_moPepGen.fasta', 'vep_moPepGen_peptide_table.txt'}
         self.assertEqual(files, expected)
 
     def test_call_variant_peptide_circ_no_canoincal(self):
@@ -193,7 +193,7 @@ class TestCallVariantPeptides(TestCaseIntegration):
         args.proteome_fasta = self.data_dir/'translate.fasta'
         cli.call_variant_peptide(args)
         files = {str(file.name) for file in self.work_dir.glob('*')}
-        expected = {'vep_moPepGen.fasta'}
+        expected = {'vep_moPepGen.fasta', 'vep_moPepGen_peptide_table.txt'}
         self.assertEqual(files, expected)
 
         seqs = list(SeqIO.parse(self.work_dir/'vep_moPepGen.fasta', 'fasta'))
@@ -216,7 +216,7 @@ class TestCallVariantPeptides(TestCaseIntegration):
         args.proteome_fasta = self.data_dir/'translate.fasta'
         cli.call_variant_peptide(args)
         files = {str(file.name) for file in self.work_dir.glob('*')}
-        expected = {'vep_moPepGen.fasta'}
+        expected = {'vep_moPepGen.fasta', 'vep_moPepGen_peptide_table.txt'}
         self.assertEqual(files, expected)
 
     def test_call_variant_peptide_fusion_only(self):
@@ -231,7 +231,7 @@ class TestCallVariantPeptides(TestCaseIntegration):
         args.proteome_fasta = self.data_dir/'translate.fasta'
         cli.call_variant_peptide(args)
         files = {str(file.name) for file in self.work_dir.glob('*')}
-        expected = {'vep_moPepGen.fasta'}
+        expected = {'vep_moPepGen.fasta', 'vep_moPepGen_peptide_table.txt'}
         self.assertEqual(files, expected)
         seqs = list(SeqIO.parse(args.output_path, 'fasta'))
         self.assertTrue(len(seqs) > 0)
@@ -278,7 +278,7 @@ class TestCallVariantPeptides(TestCaseIntegration):
         args.proteome_fasta = self.data_dir/'translate.fasta'
         cli.call_variant_peptide(args)
         files = {str(file.name) for file in self.work_dir.glob('*')}
-        expected = {'vep_moPepGen.fasta'}
+        expected = {'vep_moPepGen.fasta', 'vep_moPepGen_peptide_table.txt'}
         self.assertEqual(files, expected)
 
     def test_call_varaint_peptide_case5(self):

--- a/test/unit/test_peptide_variant_graph.py
+++ b/test/unit/test_peptide_variant_graph.py
@@ -799,7 +799,7 @@ class TestPeptideVariantGraph(unittest.TestCase):
         orf = PVGOrf([0, None])
         cursor = PVGCursor(nodes[1], nodes[3], True, [orf])
         graph.call_and_stage_known_orf(cursor,  traversal)
-        label = list(list(traversal.pool.peptides.values())[0])[0].label
+        label = list(list(traversal.pool.peptides.values())[0].values())[0].label
         self.assertEqual(label.count('|'), 1)
 
     def test_fit_into_cleavage_bridge_node_needs_merge(self):

--- a/test/unit/test_three_frame_tvg.py
+++ b/test/unit/test_three_frame_tvg.py
@@ -879,6 +879,7 @@ class TestCaseThreeFrameTVG(unittest.TestCase):
             3:  ['GTT', [2], []]
         }
         tx_id = 'ENST01'
+        gene_id = 'ENSG01'
         graph, nodes = create_three_frame_tvg(data, 'AAAAATAGTT', tx_id)
         data = {
             11: ['TGCTGC', ['RF0'], []],
@@ -893,7 +894,8 @@ class TestCaseThreeFrameTVG(unittest.TestCase):
         graph2.add_edge(nodes[1], nodes2[11], 'variant_start')
         graph.subgraphs.add_subgraph(
             child_id=subgraph_id, parent_id=tx_id, level=1,
-            start=5, end=6, variant=nodes2[13].variants[0].variant
+            start=5, end=6, variant=nodes2[13].variants[0].variant,
+            feature_id=gene_id, feature_type='gene'
         )
         graph.align_variants(nodes[1])
         out_node_seqs = {x.out_node.seq.seq for x in nodes[1].out_edges}

--- a/test/unit/test_three_frame_tvg.py
+++ b/test/unit/test_three_frame_tvg.py
@@ -893,7 +893,7 @@ class TestCaseThreeFrameTVG(unittest.TestCase):
         graph2.add_edge(nodes[1], nodes2[11], 'variant_start')
         graph.subgraphs.add_subgraph(
             child_id=subgraph_id, parent_id=tx_id, level=1,
-            start=5, end=6
+            start=5, end=6, variant=nodes2[13].variants[0].variant
         )
         graph.align_variants(nodes[1])
         out_node_seqs = {x.out_node.seq.seq for x in nodes[1].out_edges}

--- a/test/unit/test_variant_peptide_dict.py
+++ b/test/unit/test_variant_peptide_dict.py
@@ -1,6 +1,6 @@
 """ Test Module for VariantPeptideDict """
 import unittest
-from test.unit import create_aa_record, create_variants
+from test.unit import create_variants
 from Bio.Seq import Seq
 from moPepGen import params
 from moPepGen.svgraph.VariantPeptideDict import MiscleavedNodes, VariantPeptideDict, \
@@ -13,14 +13,14 @@ def create_variant_peptide_dict(tx_id, data) -> VariantPeptideDict:
     peptides = {}
     for x,y in data:
         seq = Seq(x)
-        metadatas = set()
+        metadatas = {}
         for it in y:
             variants = set(create_variants(it[0]))
             label = vpi.create_variant_peptide_id(tx_id, variants, None)
             is_pure_circ_ran = len(variants) == 1 and list(variants)[0].is_circ_rna()
             metadata = VariantPeptideMetadata(label, it[1], is_pure_circ_ran)
             metadata.has_variants = bool(variants)
-            metadatas.add(metadata)
+            metadatas[metadata.label] = metadata
         peptides[seq] = metadatas
     return VariantPeptideDict(tx_id=tx_id, peptides=peptides)
 

--- a/test/unit/test_variant_peptide_dict.py
+++ b/test/unit/test_variant_peptide_dict.py
@@ -1,6 +1,7 @@
 """ Test Module for VariantPeptideDict """
 import unittest
 from test.unit import create_aa_record, create_variants
+from Bio.Seq import Seq
 from moPepGen import params
 from moPepGen.svgraph.VariantPeptideDict import MiscleavedNodes, VariantPeptideDict, \
     VariantPeptideMetadata
@@ -11,7 +12,7 @@ def create_variant_peptide_dict(tx_id, data) -> VariantPeptideDict:
     """ create a VariantPeptideDict """
     peptides = {}
     for x,y in data:
-        seq = create_aa_record(*x)
+        seq = Seq(x)
         metadatas = set()
         for it in y:
             variants = set(create_variants(it[0]))
@@ -30,7 +31,7 @@ class TestCaseVariantPeptideDict(unittest.TestCase):
         tx_id = 'ENST0001'
         data = [
             (
-                ('SSSSSSSSSR', tx_id), [
+                'SSSSSSSSSR', [
                     (
                         [(100, 101, 'A', 'T', 'SNV', 'SNV-100-A-T', {}, 'ENST0001')],
                         [0, None]
@@ -42,11 +43,11 @@ class TestCaseVariantPeptideDict(unittest.TestCase):
             )
         ]
         pool = create_variant_peptide_dict(tx_id, data)
-        seqs = pool.get_peptide_sequences()
-        self.assertEqual({str(x.seq) for x in seqs}, {'SSSSSSSSSR'})
-        seq = list(seqs)[0]
+        res = pool.get_peptide_sequences()
+        self.assertEqual({str(x) for x in res}, {'SSSSSSSSSR'})
+        seq_data = list(res.values())[0]
         peptide_id = {f'{tx_id}|SNV-100-A-T|1', f'{tx_id}|SNV-200-G-C|1'}
-        self.assertEqual(set(seq.description.split(' ')), peptide_id)
+        self.assertEqual({x.label for x in seq_data}, peptide_id)
 
     def test_get_peptide_sequences_circ_rna(self):
         """ Get peptide sequence with circRNA """
@@ -57,7 +58,7 @@ class TestCaseVariantPeptideDict(unittest.TestCase):
         ]
         data = [
             (
-                ('SSSSSSSSSR', tx_id), [
+                'SSSSSSSSSR', [
                     ([variants[0]], [0, None]),
                     ([variants[1]], [1, None])
                 ]
@@ -65,8 +66,8 @@ class TestCaseVariantPeptideDict(unittest.TestCase):
         ]
         pool = create_variant_peptide_dict(tx_id, data)
         seqs = pool.get_peptide_sequences()
-        self.assertEqual({str(x.seq) for x in seqs}, {'SSSSSSSSSR'})
-        self.assertEqual(list(seqs)[0].description, 'CIRC-ENST0001-E1-E2-E3|1')
+        self.assertEqual({str(x) for x in seqs}, {'SSSSSSSSSR'})
+        self.assertEqual(list(seqs.values())[0][0].label, 'CIRC-ENST0001-E1-E2-E3|1')
 
 
 class TestCaseMiscleavedNodes(unittest.TestCase):


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

As described in #833, an additional table is now saved by `callVariant` with detailed annotation of each segment of the peptide, including where they are mapped to the original transcript, and whether a variant is carried. The table looks like this below.

```
#seq                   label                                        start  end  feature_type  feature_id         ref_start  ref_end  start_offset  end_offset  variant
IQGARATLUF            ENST00000614167.2|SNV-1179-G-T|1             0      5    transcript    ENST00000614167.2  306        311      2             -2          .
IQGARATLUF            ENST00000614167.2|SNV-1179-G-T|1             5      10   transcript    ENST00000614167.2  311        316      2             -2          .
RIQGARATLUF           ENST00000614167.2|SNV-1179-G-T|2             0      1    transcript    ENST00000614167.2  305        306      2             -2          .
RIQGARATLUF           ENST00000614167.2|SNV-1179-G-T|2             1      6    transcript    ENST00000614167.2  306        311      2             -2          .
RIQGARATLUF           ENST00000614167.2|SNV-1179-G-T|2             6      11   transcript    ENST00000614167.2  311        316      2             -2          .
NTLSGMQKFMGEDUNFHERK  ENST00000614167.2|SNV-611-G-A|SNV-612-A-T|1  0      2    transcript    ENST00000614167.2  201        203      2             -2          .
NTLSGMQKFMGEDUNFHERK  ENST00000614167.2|SNV-611-G-A|SNV-612-A-T|1  1      3    .             .                  .          .        2             -2          MNV-610-GA-AT
NTLSGMQKFMGEDUNFHERK  ENST00000614167.2|SNV-611-G-A|SNV-612-A-T|1  2      8    transcript    ENST00000614167.2  203        209      2             -2          .
NTLSGMQKFMGEDUNFHERK  ENST00000614167.2|SNV-611-G-A|SNV-612-A-T|1  8      19   transcript    ENST00000614167.2  209        220      2             -2          .
```

This brings another benefit. Because the peptide information is bigger than just the sequence and fasta header, I have to save them to the disk instead of holding them in the memory until the end. And since this table contains the fasta header, too, the fasta header don't need to stay in memory, either. So with this, only a `dict` of sequence and the pointers to the table is kept in the memory, and the information can be loaded quickly in the end and be converted into FASTA entries to save. So basically this should reduce memory usage, too.

Closes #833   <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
