### PR TITLE
`--backsplicing-only` added to only call backsplicing site spanning peptides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.3.1]
+
+### Added:
+
+- Flag `--backsplicing-only` added to `callVariant` to allow only calling noncanonical peptides spanning backsplicing site from circRNA events. #858
+
 ## [1.3.0] - 2024-3-11
 
 ### Fixed:

--- a/moPepGen/__init__.py
+++ b/moPepGen/__init__.py
@@ -8,7 +8,7 @@ import logging
 from . import constant
 
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 
 ## Error messages
 ERROR_INDEX_IN_INTRON = 'The genomic index seems to be in an intron'

--- a/moPepGen/svgraph/PVGNode.py
+++ b/moPepGen/svgraph/PVGNode.py
@@ -825,6 +825,19 @@ class PVGNode():
         # raise ValueError('Can not find ORF')
         return -1
 
+    def get_subgraph_id_set(self) -> Set[str]:
+        """ Get all subgraph ID as set """
+        ids = set()
+        for loc in self.seq.locations:
+            if len(loc) == 0:
+                continue
+            ids.add(loc.ref.seqname)
+        for v in self.variants:
+            if v.variant.is_circ_rna():
+                continue
+            ids.add(v.location.seqname)
+        return ids
+
     def get_subgraph_id_at(self, i:int) -> str:
         """ Get the subgraph ID at the given position """
         for loc in self.seq.locations:

--- a/moPepGen/svgraph/PeptideVariantGraph.py
+++ b/moPepGen/svgraph/PeptideVariantGraph.py
@@ -5,7 +5,7 @@ from typing import Callable, FrozenSet, Iterable, Set, Deque, Dict, List, Tuple,
 from collections import deque
 from functools import cmp_to_key
 from Bio.Seq import Seq
-from moPepGen import aa, circ, seqvar, params
+from moPepGen import aa, params
 from moPepGen.seqvar.VariantRecord import VariantRecord
 from moPepGen.svgraph.SubgraphTree import SubgraphTree
 from moPepGen.svgraph.VariantPeptideDict import VariantPeptideDict
@@ -17,7 +17,7 @@ from moPepGen.svgraph.PVGNodeCollapser import PVGNodeCollapser, PVGNodePopCollap
 if TYPE_CHECKING:
     from .VariantPeptideDict import AnnotatedPeptideLabel
     from moPepGen.circ import CircRNAModel
-    from moPepGen.seqvar.VariantRecord import VariantRecord
+    from moPepGen.params import CleavageParams
 
 T = Tuple[Set[PVGNode],Dict[PVGNode,List[PVGNode]]]
 
@@ -43,7 +43,7 @@ class PeptideVariantGraph():
             position.
     """
     def __init__(self, root:PVGNode, _id:str,
-            known_orf:List[int,int], cleavage_params:params.CleavageParams=None,
+            known_orf:List[int,int], cleavage_params:CleavageParams=None,
             orfs:Set[Tuple[int,int]]=None, reading_frames:List[PVGNode]=None,
             orf_id_map:Dict[int,str]=None, cds_start_nf:bool=False,
             hypermutated_region_warned:bool=False, denylist:Set[str]=None,

--- a/moPepGen/svgraph/PeptideVariantGraph.py
+++ b/moPepGen/svgraph/PeptideVariantGraph.py
@@ -820,7 +820,7 @@ class PeptideVariantGraph():
         - w2f (bool): Whether to consider W>F (tryptophan to phenylalanine)
             substituants.
         - check_external_variants (bool): When set to `False`, peptides not
-            harbourin any external variants will also be output. This can
+            harbouring any external variants will also be outputted. This can
             be used when calling noncanonical peptides from noncoding
             transcripts.
         """

--- a/moPepGen/svgraph/ThreeFrameCVG.py
+++ b/moPepGen/svgraph/ThreeFrameCVG.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 import copy
 from typing import Dict, Union, List, TYPE_CHECKING
 from moPepGen.SeqFeature import FeatureLocation
-from moPepGen import seqvar, params
+from moPepGen import seqvar
 from .ThreeFrameTVG import ThreeFrameTVG
 from .TVGNode import TVGNode
 
 
 if TYPE_CHECKING:
-    from moPepGen import circ
+    from moPepGen.circ import CircRNAModel
     from moPepGen.dna import DNASeqRecordWithCoordinates
     from .SubgraphTree import SubgraphTree
+    from moPepGen.params import CleavageParams
+    from moPepGen.seqvar import VariantRecordWithCoordinate, VariantRecord
 
 class ThreeFrameCVG(ThreeFrameTVG):
     """ Defines a directed cyclic graph for circular nucleotide molecules such
@@ -28,10 +30,10 @@ class ThreeFrameCVG(ThreeFrameTVG):
     def __init__(self, seq:Union[DNASeqRecordWithCoordinates,None],
             _id:str, root:TVGNode=None, reading_frames:List[TVGNode]=None,
             cds_start_nf:bool=False, has_known_orf:bool=False,
-            circ_record:circ.CircRNAModel=None, attrs:dict=None,
+            circ_record:CircRNAModel=None, attrs:dict=None,
             coordinate_feature_type:str=None, coordinate_feature_id:str=None,
             subgraphs:SubgraphTree=None, hypermutated_region_warned:bool=False,
-            cleavage_params:params.CleavageParams=None,
+            cleavage_params:CleavageParams=None,
             max_adjacent_as_mnv:int=2):
         """ Construct a CircularVariantGraph
 
@@ -72,7 +74,7 @@ class ThreeFrameCVG(ThreeFrameTVG):
             hypermutated_region_warned=hypermutated_region_warned
         )
 
-    def get_circ_variant_with_coordinate(self) -> seqvar.VariantRecordWithCoordinate:
+    def get_circ_variant_with_coordinate(self) -> VariantRecordWithCoordinate:
         """ Add a variant record to the frameshifting of the root node. This
         will treat all peptides as variant peptide in the later steps. """
         location = FeatureLocation(
@@ -95,7 +97,7 @@ class ThreeFrameCVG(ThreeFrameTVG):
             node.variants.append(var_i)
             self.add_edge(node, root, 'reference')
 
-    def create_variant_circ_graph(self, variants:List[seqvar.VariantRecord]):
+    def create_variant_circ_graph(self, variants:List[VariantRecord]):
         """ Apply a list of variants to the graph. Variants not in the
         range are ignored. Variants at the first nucleotide of each fragment
         of the sequence are also ignored, because it causes the exon splice

--- a/moPepGen/svgraph/ThreeFrameCVG.py
+++ b/moPepGen/svgraph/ThreeFrameCVG.py
@@ -29,7 +29,9 @@ class ThreeFrameCVG(ThreeFrameTVG):
             _id:str, root:TVGNode=None, reading_frames:List[TVGNode]=None,
             cds_start_nf:bool=False, has_known_orf:bool=False,
             circ_record:circ.CircRNAModel=None, attrs:dict=None,
-            subgraphs:SubgraphTree=None, cleavage_params:params.CleavageParams=None,
+            coordinate_feature_type:str=None, coordinate_feature_id:str=None,
+            subgraphs:SubgraphTree=None, hypermutated_region_warned:bool=False,
+            cleavage_params:params.CleavageParams=None,
             max_adjacent_as_mnv:int=2):
         """ Construct a CircularVariantGraph
 
@@ -64,7 +66,10 @@ class ThreeFrameCVG(ThreeFrameTVG):
             seq=seq, _id=_id, root=root, reading_frames=reading_frames,
             cds_start_nf=cds_start_nf, has_known_orf=has_known_orf,
             global_variant=circ_variant, subgraphs=subgraphs,
-            cleavage_params=cleavage_params, max_adjacent_as_mnv=max_adjacent_as_mnv
+            cleavage_params=cleavage_params, max_adjacent_as_mnv=max_adjacent_as_mnv,
+            coordinate_feature_type=coordinate_feature_type,
+            coordinate_feature_id=coordinate_feature_id,
+            hypermutated_region_warned=hypermutated_region_warned
         )
 
     def get_circ_variant_with_coordinate(self) -> seqvar.VariantRecordWithCoordinate:
@@ -149,7 +154,7 @@ class ThreeFrameCVG(ThreeFrameTVG):
             self.subgraphs.add_subgraph(
                 child_id=sub.id, parent_id=cur.id, level=sub.root.level,
                 start=self.seq.locations[-1].ref.end, end=self.seq.locations[-1].ref.end,
-                variant=self.global_variant, feature_type='gene', feature_id=self.gene_id
+                variant=self.global_variant, feature_type='gene', feature_id=self.circ.gene_id
             )
             for edge in sub.root.out_edges:
                 root = edge.out_node

--- a/moPepGen/svgraph/ThreeFrameTVG.py
+++ b/moPepGen/svgraph/ThreeFrameTVG.py
@@ -20,7 +20,10 @@ from moPepGen.svgraph.TVGNodeCollapser import TVGNodeCollapser
 
 
 if TYPE_CHECKING:
-    from moPepGen import gtf
+    from moPepGen.gtf import GenomicAnnotation
+    from moPepGen.params import CleavageParams
+    from moPepGen.dna import DNASeqDict
+    from moPepGen.seqvar import VariantRecord
 
 class ThreeFrameTVG():
     """ Defines the DAG data structure for the transcript and its variants.
@@ -38,14 +41,14 @@ class ThreeFrameTVG():
         global_variant (VariantRecord)
         id (str)
     """
-    def __init__(self, seq:Union[dna.DNASeqRecordWithCoordinates,None],
+    def __init__(self, seq:Union[DNASeqRecordWithCoordinates,None],
             _id:str, root:TVGNode=None, reading_frames:List[TVGNode]=None,
             cds_start_nf:bool=False, has_known_orf:bool=None,
-            mrna_end_nf:bool=False, global_variant:seqvar.VariantRecord=None,
+            mrna_end_nf:bool=False, global_variant:VariantRecord=None,
             coordinate_feature_type:str=None, coordinate_feature_id:str=None,
             subgraphs:SubgraphTree=None, hypermutated_region_warned:bool=False,
-            cleavage_params:params.CleavageParams=None, gene_id:str=None,
-            sect_variants:List[seqvar.VariantRecordWithCoordinate]=None,
+            cleavage_params:CleavageParams=None, gene_id:str=None,
+            sect_variants:List[VariantRecordWithCoordinate]=None,
             max_adjacent_as_mnv:int=2):
         """ Constructor to create a TranscriptVariantGraph object. """
         self.seq = seq
@@ -299,9 +302,9 @@ class ThreeFrameTVG():
                         queue.append(out_node)
         return targets
 
-    def gather_sect_variants(self, anno:gtf.GenomicAnnotation):
+    def gather_sect_variants(self, anno:GenomicAnnotation):
         """ Create selenocysteine trunction map """
-        sect_variants:List[seqvar.VariantRecordWithCoordinate] = []
+        sect_variants:List[VariantRecordWithCoordinate] = []
         for sec in self.seq.selenocysteine:
             sect_var = seqvar.create_variant_sect(anno, self.id, sec.start)
             sect_loc = FeatureLocation(sec.start, sec.end)
@@ -316,10 +319,10 @@ class ThreeFrameTVG():
         sequence """
         return node.get_orf_start(i) % 3
 
-    def create_node(self, seq:dna.DNASeqRecordWithCoordinates,
-            variants:List[seqvar.VariantRecordWithCoordinate]=None,
+    def create_node(self, seq:DNASeqRecordWithCoordinates,
+            variants:List[VariantRecordWithCoordinate]=None,
             branch:bool=False, orf:List[int]=None, reading_frame_index:int=None,
-            subgraph_id:str=None, level:int=0, global_variant:seqvar.VariantRecord=None
+            subgraph_id:str=None, level:int=0, global_variant:VariantRecord=None
             ) -> TVGNode:
         """ create a node """
         return TVGNode(
@@ -373,7 +376,7 @@ class ThreeFrameTVG():
         return left_node, right_node
 
     def apply_variant(self, source:TVGNode, target:TVGNode,
-            variant:seqvar.VariantRecord) -> TVGNode:
+            variant:VariantRecord) -> TVGNode:
         """ Apply a given variant to the graph.
 
         For a given genomic variant with the coordinates of the transcript,
@@ -385,7 +388,7 @@ class ThreeFrameTVG():
 
         Args:
             node [node]: The node where the variant to be add.
-            variant [seqvar.VariantRecord]: The variant record.
+            variant [VariantRecord]: The variant record.
 
         Returns:
             The reference node (unmutated) with the same location as the
@@ -493,9 +496,9 @@ class ThreeFrameTVG():
         return returns
 
     def insert_flanking_variant(self, cursors:List[TVGNode],
-            var:seqvar.VariantRecordWithCoordinate,
+            var:VariantRecordWithCoordinate,
             seq:DNASeqRecordWithCoordinates,
-            variants:List[seqvar.VariantRecord], position:int,
+            variants:List[VariantRecord], position:int,
             attach_directly:bool=False, known_orf_index:int=None,
             coordinate_feature_type:str=None, coordinate_feature_id:str=None
             ) -> List[TVGNode]:
@@ -607,11 +610,11 @@ class ThreeFrameTVG():
 
         return var_tails
 
-    def apply_fusion(self, cursors:List[TVGNode], variant:seqvar.VariantRecord,
-            variant_pool:VariantRecordPoolOnDisk, genome:dna.DNASeqDict,
-            anno:gtf.GenomicAnnotation,
-            tx_seqs:Dict[str,dna.DNASeqRecordWithCoordinates]=None,
-            gene_seqs:Dict[str,dna.DNASeqRecordWithCoordinates]=None,
+    def apply_fusion(self, cursors:List[TVGNode], variant:VariantRecord,
+            variant_pool:VariantRecordPoolOnDisk, genome:DNASeqDict,
+            anno:GenomicAnnotation,
+            tx_seqs:Dict[str,DNASeqRecordWithCoordinates]=None,
+            gene_seqs:Dict[str,DNASeqRecordWithCoordinates]=None,
             known_orf_index:int=None
             ) -> List[TVGNode]:
         """ Apply a fusion variant, by creating a subgraph of the donor
@@ -763,8 +766,8 @@ class ThreeFrameTVG():
 
     def _apply_insertion(self, cursors:List[TVGNode],
             var:seqvar.VariantRecordWithCoordinate,
-            seq:dna.DNASeqRecordWithCoordinates,
-            variants:List[seqvar.VariantRecord], active_frames:List[bool],
+            seq:DNASeqRecordWithCoordinates,
+            variants:List[VariantRecord], active_frames:List[bool],
             coordinate_feature_type:str, coordinate_feature_id:str
         ) -> List[TVGNode]:
         """ This is a wrapper function to apply insertions to the graph. It can
@@ -887,10 +890,10 @@ class ThreeFrameTVG():
         return cursors
 
     def apply_insertion(self, cursors:List[TVGNode],
-            variant:seqvar.VariantRecord,
+            variant:VariantRecord,
             variant_pool:VariantRecordPoolOnDisk,
-            genome:dna.DNASeqDict, anno:gtf.GenomicAnnotation,
-            gene_seqs:Dict[str, dna.DNASeqRecordWithCoordinates]=None,
+            genome:DNASeqDict, anno:GenomicAnnotation,
+            gene_seqs:Dict[str, DNASeqRecordWithCoordinates]=None,
             active_frames:List[bool]=None
             ) -> List[TVGNode]:
         """ Apply an insertion into the the TVG graph. """
@@ -941,10 +944,10 @@ class ThreeFrameTVG():
         )
 
     def apply_substitution(self, cursors:List[TVGNode],
-            variant:seqvar.VariantRecord,
+            variant:VariantRecord,
             variant_pool:VariantRecordPoolOnDisk,
-            genome:dna.DNASeqDict, anno:gtf.GenomicAnnotation,
-            gene_seqs:Dict[str, dna.DNASeqRecordWithCoordinates]=None,
+            genome:DNASeqDict, anno:GenomicAnnotation,
+            gene_seqs:Dict[str, DNASeqRecordWithCoordinates]=None,
             active_frames:List[bool]=None
             ) -> List[TVGNode]:
         """ Apply a substitution variant into the graph """
@@ -978,11 +981,11 @@ class ThreeFrameTVG():
         )
 
 
-    def create_variant_graph(self, variants:List[seqvar.VariantRecord],
+    def create_variant_graph(self, variants:List[VariantRecord],
             variant_pool:Union[VariantRecordWithCoordinate, VariantRecordPoolOnDisk],
-            genome:dna.DNASeqDict, anno:gtf.GenomicAnnotation,
-            tx_seqs:Dict[str, dna.DNASeqRecordWithCoordinates]=None,
-            gene_seqs:Dict[str, dna.DNASeqRecordWithCoordinates]=None,
+            genome:DNASeqDict, anno:GenomicAnnotation,
+            tx_seqs:Dict[str, DNASeqRecordWithCoordinates]=None,
+            gene_seqs:Dict[str, DNASeqRecordWithCoordinates]=None,
             active_frames:List[bool]=None, known_orf_index:int=None,
             unmutated_start_size:int=3) -> None:
         """ Create a variant graph.

--- a/moPepGen/svgraph/VariantPeptideDict.py
+++ b/moPepGen/svgraph/VariantPeptideDict.py
@@ -709,7 +709,7 @@ class VariantPeptideDict():
         - `node` (PVGNode): The start node.
         - `orfs` (List[int, int]): The start and end position of the ORF.
         - `cleavage_params` (CleavageParams): Cleavage related parameters.
-        - `check_variants` (bool): Whether to check variants.
+        - `check_variants` (bool): Whether to check for variants.
         - `is_start_codon` (bool): Whether the peptide starts with the start
             codon (M).
         - `additional_variants` (List[VariantRecord]): Additional variants,

--- a/moPepGen/svgraph/VariantPeptideDict.py
+++ b/moPepGen/svgraph/VariantPeptideDict.py
@@ -666,7 +666,7 @@ class VariantPeptideDict():
                 new_batch.append(_node)
 
                 if backsplicing_only:
-                    # Skip peptides not spaning the backsplicing the site.
+                    # Skip peptides not spaning the backsplicing site
                     subgraph_ids = set().union(*[n.get_subgraph_id_set() for n in cur_batch])
                     if len(subgraph_ids) == 1:
                         continue

--- a/moPepGen/svgraph/VariantPeptideDict.py
+++ b/moPepGen/svgraph/VariantPeptideDict.py
@@ -707,7 +707,7 @@ class VariantPeptideDict():
 
         Args:
         - `node` (PVGNode): The start node.
-        - `orfs` (List[int, int]): The start and end position of ORF.
+        - `orfs` (List[int, int]): The start and end position of the ORF.
         - `cleavage_params` (CleavageParams): Cleavage related parameters.
         - `check_variants` (bool): Whether to check variants.
         - `is_start_codon` (bool): Whether the peptide starts with the start

--- a/moPepGen/svgraph/VariantPeptideTable.py
+++ b/moPepGen/svgraph/VariantPeptideTable.py
@@ -85,7 +85,7 @@ class VariantPeptideTable:
             self.handle.seek(start)
             buffer:str = self.handle.read(end - start)
             for line in buffer.rstrip().split('\n'):
-                fields = {k:v for k,v in zip(VARIANT_PEPTIDE_TABLE_HEADERS, line.split('\t'))}
+                fields = dict(zip(VARIANT_PEPTIDE_TABLE_HEADERS, line.split('\t')))
                 if seq != fields['sequence']:
                     raise ValueError(
                         f"Peptide ({seq}) do not match with table record ({fields[0]})."

--- a/moPepGen/svgraph/VariantPeptideTable.py
+++ b/moPepGen/svgraph/VariantPeptideTable.py
@@ -4,29 +4,30 @@ from typing import TYPE_CHECKING, Dict, Set, IO, List, Tuple
 from Bio import SeqUtils
 from Bio.SeqIO import FastaIO
 from moPepGen import VARIANT_PEPTIDE_SOURCE_DELIMITER, aa
+from moPepGen.SeqFeature import FeatureLocation
+from moPepGen.svgraph.VariantPeptideDict import AnnotatedPeptideLabel, PeptideSegment
 
 
 if TYPE_CHECKING:
     from pathlib import Path
     from Bio.Seq import Seq
-    from moPepGen.svgraph.VariantPeptideDict import AnnotatedPeptideLabel
     from moPepGen.params import CleavageParams
 
 VARIANT_PEPTIDE_TABLE_HEADERS = [
-    '#sequence', 'header', 'subsequence', 'start', 'end', 'feature_type', 'feature_id',
+    'sequence', 'header', 'subsequence', 'start', 'end', 'feature_type', 'feature_id',
     'ref_start', 'ref_end', 'start_offset', 'end_offset', 'variant'
 ]
 
 class VariantPeptideTable:
     """ Variant Peptide Segment Annotation """
-    def __init__(self, handle:IO, index:Dict[Seq, List[Tuple[int,int]]]=None):
+    def __init__(self, handle:IO[str], index:Dict[Seq, List[Tuple[int,int]]]=None):
         self.handle = handle
         self.index = index or {}
         self.header_delimeter = VARIANT_PEPTIDE_SOURCE_DELIMITER
 
     def write_header(self):
         """ Write header """
-        self.handle.write('\t'.join(VARIANT_PEPTIDE_TABLE_HEADERS) + '\n')
+        self.handle.write('#' + '\t'.join(VARIANT_PEPTIDE_TABLE_HEADERS) + '\n')
 
     def is_valid(self, seq:Seq, canonical_peptides:Set[str],
             cleavage_params:CleavageParams=None):
@@ -56,7 +57,7 @@ class VariantPeptideTable:
         else:
             self.index[seq] = [cur]
 
-    def load_pepitde(self, seq:Seq):
+    def load_peptide(self, seq:Seq):
         """ Load peptide from table """
         labels = set()
         for start, end in self.index[seq]:
@@ -77,11 +78,76 @@ class VariantPeptideTable:
             name=label
         )
 
+    def load_peptide_annotation(self, seq):
+        """ Load peptide annotation """
+        anno:Dict[str, AnnotatedPeptideLabel] = {}
+        for start, end in self.index[seq]:
+            self.handle.seek(start)
+            buffer:str = self.handle.read(end - start)
+            for line in buffer.rstrip().split('\n'):
+                fields = {k:v for k,v in zip(VARIANT_PEPTIDE_TABLE_HEADERS, line.split('\t'))}
+                if seq != fields['sequence']:
+                    raise ValueError(
+                        f"Peptide ({seq}) do not match with table record ({fields[0]})."
+                    )
+                header = fields['header']
+                label = anno.setdefault(header, AnnotatedPeptideLabel(label=header, segments=[]))
+                query = FeatureLocation(
+                    start=int(fields['start']),
+                    end=int(fields['end']),
+                    start_offset=int(fields['start_offset']),
+                    end_offset=int(fields['end_offset'])
+                )
+                feature_type = fields['feature_type'] if fields['feature_type'] != '.' else None
+                feature_id = fields['feature_id'] if fields['feature_id'] != '.' else None
+
+                if fields['ref_start'] != '.':
+                    ref_start_raw = int(fields['ref_start'])
+                    ref_start = int(ref_start_raw / 3)
+                    ref_start_offset = ref_start_raw - ref_start * 3
+                    ref_end_raw = int(fields['ref_end'])
+                    ref_end = int(ref_end_raw / 3)
+                    ref_end_offset = ref_end_raw - ref_end * 3
+
+                    ref = FeatureLocation(
+                        start=ref_start,
+                        end=ref_end,
+                        start_offset=ref_start_offset,
+                        end_offset=ref_end_offset
+                    )
+                else:
+                    ref = None
+                variant = fields['variant'] if fields['variant'] != '.' else None
+                seg = PeptideSegment(
+                    query=query, ref=ref, feature_type=feature_type,
+                    feature_id=feature_id, variant_id=variant
+                )
+                label.segments.append(seg)
+        return anno
+
     def write_fasta(self, path:Path):
         """ write fasta """
         with open(path, 'wt') as handle:
             record2title = lambda x: x.description
             writer = FastaIO.FastaWriter(handle, record2title=record2title)
             for seq in self.index:
-                peptide = self.load_pepitde(seq)
+                peptide = self.load_peptide(seq)
                 writer.write_record(peptide)
+
+    def generate_index(self):
+        """ Generate index from peptide table file. """
+        self.handle.seek(0)
+        while True:
+            cur_start = self.handle.tell()
+            line = self.handle.readline()
+            cur_end = cur_start + len(line)
+            if not line:
+                break
+            if line.startswith('#'):
+                continue
+            seq = line.split('\t')[0]
+            indices = self.index.setdefault(seq, [])
+            if indices and indices[-1][1] == cur_start:
+                indices[-1] = (indices[-1][0], cur_end)
+            else:
+                indices.append((cur_start, cur_end))

--- a/moPepGen/svgraph/VariantPeptideTable.py
+++ b/moPepGen/svgraph/VariantPeptideTable.py
@@ -88,7 +88,7 @@ class VariantPeptideTable:
                 fields = dict(zip(VARIANT_PEPTIDE_TABLE_HEADERS, line.split('\t')))
                 if seq != fields['sequence']:
                     raise ValueError(
-                        f"Peptide ({seq}) do not match with table record ({fields[0]})."
+                        f"Peptide ({seq}) does not match with table record ({fields[0]})."
                     )
                 header = fields['header']
                 label = anno.setdefault(header, AnnotatedPeptideLabel(label=header, segments=[]))

--- a/moPepGen/util/fuzz_test.py
+++ b/moPepGen/util/fuzz_test.py
@@ -619,6 +619,7 @@ class FuzzTestCase():
         else:
             args.graph_output_dir = None
         args.quiet = True
+        args.backsplicing_only = False
         args.max_adjacent_as_mnv = 2
         args.selenocysteine_termination = True
         args.w2f_reassignment = True

--- a/moPepGen/util/validate_variant_calling.py
+++ b/moPepGen/util/validate_variant_calling.py
@@ -105,6 +105,7 @@ def call_variant(gvf_files:Path, ref_dir:Path, output_fasta:Path, graph_output_d
     args.proteome_fasta = ref_dir/'proteome.fasta'
     args.reference_source = None
     args.max_adjacent_as_mnv = 2
+    args.backsplicing_only = False
     args.selenocysteine_termination = True
     args.w2f_reassignment = True
     args.invalid_protein_as_noncoding = False


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

Flag `--backsplicing-only` is added to only output noncanonical peptides from circRNA that are spanning backsplicing sites.

Below is an example of the peptide table. For every peptide, there is at least a pair of adjacent segments that the first has larger gene coordinates than the second, meaning it is spanning the backsplicing site.

```
#sequence             header                          subsequence       start  end  feature_type  feature_id          ref_start  ref_end  start_offset  end_offset  variant
MKPLVVDISER           CIRC-ENST00000614167.2-E2-E1|1  MKPL              0      4    gene          ENSG00000128408.9   393        405      0             0           CIRC-ENST00000614167.2-E2-E1
MKPLVVDISER           CIRC-ENST00000614167.2-E2-E1|1  VVDISER           4      11   gene          ENSG00000128408.9   0          21       0             0           CIRC-ENST00000614167.2-E2-E1
KPLVVDISER            CIRC-ENST00000614167.2-E2-E1|2  KPL               0      3    gene          ENSG00000128408.9   396        405      0             0           CIRC-ENST00000614167.2-E2-E1
KPLVVDISER            CIRC-ENST00000614167.2-E2-E1|2  VVDISER           3      10   gene          ENSG00000128408.9   0          21       0             0           CIRC-ENST00000614167.2-E2-E1
MKPLVVDISERAGASVPLR   CIRC-ENST00000614167.2-E2-E1|3  MKPL              0      4    gene          ENSG00000128408.9   393        405      0             0           CIRC-ENST00000614167.2-E2-E1
MKPLVVDISERAGASVPLR   CIRC-ENST00000614167.2-E2-E1|3  VVDISERAGASVPLR   4      19   gene          ENSG00000128408.9   0          45       0             0           CIRC-ENST00000614167.2-E2-E1
KPLVVDISERAGASVPLR    CIRC-ENST00000614167.2-E2-E1|4  KPL               0      3    gene          ENSG00000128408.9   396        405      0             0           CIRC-ENST00000614167.2-E2-E1
KPLVVDISERAGASVPLR    CIRC-ENST00000614167.2-E2-E1|4  VVDISERAGASVPLR   3      18   gene          ENSG00000128408.9   0          45       0             0           CIRC-ENST00000614167.2-E2-E1
MKPLVVDISERAGASVPLRR  CIRC-ENST00000614167.2-E2-E1|5  MKPL              0      4    gene          ENSG00000128408.9   393        405      0             0           CIRC-ENST00000614167.2-E2-E1
MKPLVVDISERAGASVPLRR  CIRC-ENST00000614167.2-E2-E1|5  VVDISERAGASVPLRR  4      20   gene          ENSG00000128408.9   0          48       0             0           CIRC-ENST00000614167.2-E2-E1
KPLVVDISERAGASVPLRR   CIRC-ENST00000614167.2-E2-E1|6  KPL               0      3    gene          ENSG00000128408.9   396        405      0             0           CIRC-ENST00000614167.2-E2-E1
KPLVVDISERAGASVPLRR   CIRC-ENST00000614167.2-E2-E1|6  VVDISERAGASVPLRR  3      19   gene          ENSG00000128408.9   0          48       0             0           CIRC-ENST00000614167.2-E2-E1
MPFRRSTSGPSK          CIRC-ENST00000642151.1-E1-E2|1  MPFR              0      4    gene          ENSG00000099949.21  130        142      0             0           CIRC-ENST00000642151.1-E1-E2
MPFRRSTSGPSK          CIRC-ENST00000642151.1-E1-E2|1  RRSTSGPSK         3      12   gene          ENSG00000099949.21  -1         26       1             0           CIRC-ENST00000642151.1-E1-E2
PFRRSTSGPSK           CIRC-ENST00000642151.1-E1-E2|2  PFR               0      3    gene          ENSG00000099949.21  133        142      0             0           CIRC-ENST00000642151.1-E1-E2
PFRRSTSGPSK           CIRC-ENST00000642151.1-E1-E2|2  RRSTSGPSK         2      11   gene          ENSG00000099949.21  -1         26       1             0           CIRC-ENST00000642151.1-E1-E2
```

Closes #858   <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [x] All test cases passed locally.
