### PR TITLE
Fix VariantPeptidePool Peptide not recognized correctly during validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.4.1] - 2024-05-26
+
+- Fixed `VariantPepidePool` that old versions of `SeqUtils.molecular_weight` don't handle `SeqRecord` objects. #874
+
 ## [1.4.0] - 2024-03-27
 
 - `--coding-novel-orf` added to `callNoncoding` and `callVariant` to call novel ORF peptides from coding transcripts. #659

--- a/moPepGen/__init__.py
+++ b/moPepGen/__init__.py
@@ -8,7 +8,7 @@ import logging
 from . import constant
 
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 
 ## Error messages
 ERROR_INDEX_IN_INTRON = 'The genomic index seems to be in an intron'

--- a/moPepGen/aa/VariantPeptidePool.py
+++ b/moPepGen/aa/VariantPeptidePool.py
@@ -36,9 +36,9 @@ class VariantPeptidePool():
             min_mw = cleavage_params.min_mw
             min_length = cleavage_params.min_length
             max_length = cleavage_params.max_length
-            if SeqUtils.molecular_weight(peptide, 'protein') < min_mw:
+            if SeqUtils.molecular_weight(peptide.seq, 'protein') < min_mw:
                 return False
-            if len(peptide.seq) < min_length or len(peptide) > max_length:
+            if len(peptide.seq) < min_length or len(peptide.seq) > max_length:
                 return False
             if str(peptide.seq) in canonical_peptides:
                 return False


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

The `SeqUtils.molecular_weight` function from some older versions of Biopython don't accept `SeqRecord` as input, causing an error when trying to calculate the molecular weight.

Closes #874   <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
