### PR TITLE
Fix splitFasta: NovelORF peptides from coding transcripts not recognized correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.4.2] - 2024-06-23
+
+- Fixed `splitFasta` that NovelORF peptides coding transcripts not recognized correctly.
+
 ## [1.4.1] - 2024-05-26
 
 - Fixed `VariantPepidePool` that old versions of `SeqUtils.molecular_weight` don't handle `SeqRecord` objects. #874

--- a/moPepGen/__init__.py
+++ b/moPepGen/__init__.py
@@ -8,7 +8,7 @@ import logging
 from . import constant
 
 
-__version__ = '1.4.1'
+__version__ = '1.4.2'
 
 ## Error messages
 ERROR_INDEX_IN_INTRON = 'The genomic index seems to be in an intron'

--- a/moPepGen/aa/VariantPeptideLabel.py
+++ b/moPepGen/aa/VariantPeptideLabel.py
@@ -203,7 +203,7 @@ class VariantPeptideInfo():
             info = VariantPeptideInfo(str(variant_id), gene_ids, var_ids, variant_id.index)
 
             if check_source:
-                if tx_id not in coding_tx:
+                if variant_id.orf_id is not None:
                     info.sources.add(constant.SOURCE_NOVEL_ORF, group_map=group_map)
 
                 for gene_id, _ids in var_ids.items():

--- a/test/unit/test_peptide_pool_splitter.py
+++ b/test/unit/test_peptide_pool_splitter.py
@@ -283,7 +283,7 @@ class TestVariantPeptideInfo(unittest.TestCase):
         infos = VariantPeptideInfo.from_variant_peptide(peptide, tx2gene, coding_tx, label_map)
         self.assertIn('NovelORF', infos[0].sources)
 
-        peptide = create_aa_record('KHIRJ','ENST0004|1')
+        peptide = create_aa_record('KHIRJ','ENST0004|ORF1|1')
         infos = VariantPeptideInfo.from_variant_peptide(peptide, tx2gene, coding_tx, label_map)
         self.assertIn('NovelORF', infos[0].sources)
 
@@ -543,7 +543,7 @@ class TestPeptidePoolSplitter(unittest.TestCase):
         peptides_data = [
             [
                 'SSSSSSSR',
-                'CIRC-ENST0002-E1-E2|1 ENST0005|SE-2100|1'
+                'CIRC-ENST0002-E1-E2|1 ENST0005|SE-2100|ORF2|1'
             ]
         ]
         peptides = VariantPeptidePool({create_aa_record(*x) for x in peptides_data})
@@ -576,7 +576,7 @@ class TestPeptidePoolSplitter(unittest.TestCase):
         peptides_data = [
             [
                 'SSSSFSSR',
-                'CIRC-ENST0002-E1-E2|1 ENST0005|SE-2100|W2F-5|1'
+                'CIRC-ENST0002-E1-E2|1 ENST0005|SE-2100|W2F-5|ORF-2|1'
             ]
         ]
         peptides = VariantPeptidePool({create_aa_record(*x) for x in peptides_data})

--- a/test/unit/test_peptide_pool_summarizer.py
+++ b/test/unit/test_peptide_pool_summarizer.py
@@ -50,7 +50,7 @@ class TestPeptidePoolSummarizer(unittest.TestCase):
         peptides_data = [
             [
                 'SSSSSSSR',
-                'CIRC-ENST0002-E1-E2|1 ENST0005|SE-2100|1'
+                'CIRC-ENST0002-E1-E2|1 ENST0005|SE-2100|ORF2|1'
             ]
         ]
         peptides = VariantPeptidePool({create_aa_record(*x) for x in peptides_data})


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

Closes #...  <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [x] All test cases passed locally.
