### PR TITLE
Fix Documentation

### DIFF
--- a/docs/parse-vep.md
+++ b/docs/parse-vep.md
@@ -29,7 +29,7 @@ moPepGen relies on Ensembl Variant Effect Predictor ([VEP](https://www.ensembl.o
 
 Please refer to the official [VEP Tutorial](https://www.ensembl.org/info/docs/tools/vep/script/vep_tutorial.html) for instructions on downloading, installing and running VEP. The key is to ensure that the annotation version used in `VEP` is the same as the one you would like to use with moPepGen.
 
-`parseVEP` currently only supports the TSV output of `VEP`, please set the suffix of `--output_file` to `.tsv` to ensure the correct format is outputted by `VEP`.
+`parseVEP` currently only supports the TSV output of `VEP`, please set the suffix of `--output_file` to `.tsv` to ensure the correct format is outputted by `VEP`. `VEP`'s default output format is tab-delimited, and the `--tab` option adds extra columns to the output that are not used by moPepGen. So including or excluding `--tab` will not impact the results of moPepGen.
 
 ### Using an Ensembl GTF
 


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

Clarify in documentation that the default output of VEP is tab-delimited and `--tab` won't change anything.

Closes #882   <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
