### PR TITLE
Fix callVariant, apply max_variant_per_node to cleavage graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.4.3] - 2025-01-18
+
 ### Fixed
 
 - Fixed `VariantPeptideIdentifier` that ORF ID was added before variant IDs.
+
+- Fixed `callVariant` that failed on small circRNA with a lot of variants at the step that creates the cleavage graph. #885
 
 ### Changed
 

--- a/moPepGen/svgraph/PeptideVariantGraph.py
+++ b/moPepGen/svgraph/PeptideVariantGraph.py
@@ -303,6 +303,11 @@ class PeptideVariantGraph():
         inbridge_list:Dict[PVGNode,List[PVGNode]] = {}
 
         for route in routes:
+            if self.nodes_have_too_many_variants(route):
+                for i, node in enumerate(route):
+                    if i > 0:
+                        trash.add((route[i-1], node))
+                continue
             for i,node in enumerate(route):
                 node_is_bridge = node.is_bridge()
                 if i == 0:


### PR DESCRIPTION
…the step that creates the cleavage graph. #885

## Description
<!--- Briefly describe the changes included in this pull request  --->

Closes #885  <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
