### PR TITLE
`splitFasta`: Add support for wildcards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.4.6-rc4] - 2025-03-18
+
+- Added the support for wildcard characters in `splitFasta`. #906
+
 ## [1.4.6-rc3] - 2025-03-10
 
 - Added --skip-failed flag to callVariant, parseArriba, parserSTARFusion, parseFusionCatcher.

--- a/moPepGen/__init__.py
+++ b/moPepGen/__init__.py
@@ -8,7 +8,7 @@ import logging
 from . import constant
 
 
-__version__ = '1.4.6-rc3'
+__version__ = '1.4.6-rc4'
 
 ## Error messages
 ERROR_INDEX_IN_INTRON = 'The genomic index seems to be in an intron'

--- a/moPepGen/aa/PeptidePoolSplitter.py
+++ b/moPepGen/aa/PeptidePoolSplitter.py
@@ -44,11 +44,11 @@ class PeptidePoolSplitter():
             self.sources = sources
         else:
             self.sources = set()
-            for sources in self.order:
+            for source_group in self.order:
                 if isinstance(sources, str):
-                    self.sources.add(sources)
+                    self.sources.add(source_group)
                 else:
-                    self.sources.update([s for s in sources if s not in ['+', '*']])
+                    self.sources.update([s for s in source_group if s not in ['+', '*']])
 
     def get_reversed_group_map(self) -> Dict[str, List[str]]:
         """ Reverse group map """
@@ -145,7 +145,8 @@ class PeptidePoolSplitter():
             start = 0 if '*' in sources else 1
             for i in range(start, len(individual_sources)):
                 for extra_sources in itertools.combinations(individual_sources, i):
-                    expanded_sources = [x for x in sources if x not in wildcard_chrs] + list(extra_sources)
+                    expanded_sources = [x for x in sources if x not in wildcard_chrs] \
+                        + list(extra_sources)
                     expanded_sources = frozenset(expanded_sources)
                     if expanded_sources not in wildcard_map:
                         wildcard_map[expanded_sources] = sources

--- a/moPepGen/aa/VariantPeptideLabel.py
+++ b/moPepGen/aa/VariantPeptideLabel.py
@@ -1,10 +1,11 @@
 """ module for peptide peptide labels """
 from __future__ import annotations
-from typing import Dict, Iterable, List, TYPE_CHECKING, Set
+from typing import TYPE_CHECKING
 from moPepGen import err, seqvar, circ, constant, SPLIT_DATABASE_KEY_SEPARATER
 from . import VariantPeptideIdentifier as pi
 
 if TYPE_CHECKING:
+    from typing import Dict, Iterable, List, Set, FrozenSet
     from .AminoAcidSeqRecord import AminoAcidSeqRecord
     from moPepGen.gtf import GenomicAnnotation
 
@@ -26,7 +27,8 @@ class VariantSourceSet(set):
     def __init__(self, *args):
         """ constructor """
         for it in list(*args):
-            self.validate(it)
+            if it not in ['+', '*']:
+                self.validate(it)
         super().__init__(*args)
 
     def validate(self, it):
@@ -58,7 +60,11 @@ class VariantSourceSet(set):
 
     def __str__(self) -> str:
         """ str """
-        sorted_list = [x for x in self.levels if x in self]
+        sorted_list = [x for x in self.levels if x in self and x not in ['+', '*']]
+        if '*' in self:
+            sorted_list.append('ALL')
+        elif '+' in self:
+            sorted_list.append('PLUS')
         return SPLIT_DATABASE_KEY_SEPARATER.join(sorted_list)
 
     def __gt__(self, other:VariantSourceSet) -> bool:
@@ -161,11 +167,14 @@ class VariantPeptideInfo():
     def from_variant_peptide(peptide:AminoAcidSeqRecord,
             tx2gene:Dict[str,str], coding_tx:Set[str],
             label_map:LabelSourceMapping=None,
-            check_source:bool=True, group_map:Dict[str,str]=None
+            check_source:bool=True, group_map:Dict[str,str]=None,
+            wildcard_map:Dict[FrozenSet[str],FrozenSet[str]]=None
             ) -> List[VariantPeptideInfo]:
         """ Parse from a variant peptide record """
         if group_map is None:
             group_map = {}
+        if wildcard_map is None:
+            wildcard_map = {}
         info_list = []
         variant_ids = pi.parse_variant_peptide_id(peptide.description, coding_tx)
         for variant_id in variant_ids:
@@ -226,7 +235,11 @@ class VariantPeptideInfo():
                         else:
                             source = label_map.get_source(gene_id, var_id)
                             info.sources.add(source, group_map=group_map)
-
+                try:
+                    sources = wildcard_map[frozenset(info.sources)]
+                    info.sources = VariantSourceSet(sources)
+                except KeyError:
+                    pass
             info_list.append(info)
         return info_list
 

--- a/moPepGen/cli/split_fasta.py
+++ b/moPepGen/cli/split_fasta.py
@@ -66,7 +66,10 @@ def add_subparser_split_fasta(subparser:argparse._SubParsersAction):
     p.add_argument(
         '--order-source',
         type=str,
-        help='Order of sources, separate by comma. E.g., SNP,SNV,Fusion',
+        help='Order of sources, separate by comma (e.g., SNP,SNV,Fusion). Whildcard'
+        ' characters are supported. "SNV-*" will match all peptides with SNV with'
+        ' or without other variant sources. "SNV-+" will match all peptides with'
+        ' SNV with at least another variant source.',
         metavar='<value>'
     )
     p.add_argument(

--- a/test/integration/test_split_fasta.py
+++ b/test/integration/test_split_fasta.py
@@ -230,7 +230,7 @@ class TestSplitDatabase(TestCaseIntegration):
         self.assertEqual(files, expected)
 
     def test_split_fasta_source_order_wildcards(self):
-        """ test splitFasta with source order of combinations """
+        """ test splitFasta with source order of combinations with wildcards """
         args = self.create_base_args()
         args.gvf = [
             self.data_dir/'vep/vep_gSNP.gvf',

--- a/test/integration/test_split_fasta.py
+++ b/test/integration/test_split_fasta.py
@@ -228,3 +228,40 @@ class TestSplitDatabase(TestCaseIntegration):
             'test_Remaining.fasta', 'test_CodonReassign.fasta'
         }
         self.assertEqual(files, expected)
+
+    def test_split_fasta_source_order_wildcards(self):
+        """ test splitFasta with source order of combinations """
+        args = self.create_base_args()
+        args.gvf = [
+            self.data_dir/'vep/vep_gSNP.gvf',
+            self.data_dir/'vep/vep_gINDEL.gvf',
+            self.data_dir/'reditools/reditools.gvf',
+            self.data_dir/'fusion/star_fusion.gvf',
+            self.data_dir/'circRNA/circ_rna.gvf'
+        ]
+        args.variant_peptides = self.data_dir/'peptides/variant.fasta'
+        args.novel_orf_peptides = self.data_dir/'peptides/novel_orf.fasta'
+        args.alt_translation_peptides = self.data_dir/'peptides/alt_translation.fasta'
+        args.annotation_gtf = self.data_dir/'annotation.gtf'
+        args.proteome_fasta = self.data_dir/'translate.fasta'
+        args.group_source = [
+            'Alt:SECT,CodonReassign',
+            'Variant:gSNP,gINDEL,sSNV,sINDEL,Fusion,altSplice,RNAEditingSite'
+        ]
+        args.order_source = ','.join([
+            'Variant',
+            'NovelORF',
+            'Variant-NovelORF',
+            'circRNA',
+            'circRNA-+',
+            'Alt-*'
+        ])
+        args.max_source_groups = 4
+        cli.split_fasta(args)
+        files = {str(file.name) for file in self.work_dir.glob('*')}
+        expected = {
+            'test_Variant.fasta', 'test_NovelORF.fasta',
+            'test_Variant-NovelORF.fasta', 'test_circRNA.fasta',
+            'test_circRNA-PLUS.fasta', 'test_Alt-ALL.fasta'
+        }
+        self.assertEqual(files, expected)


### PR DESCRIPTION
Wildcards are supported (`+` & `*`).

When use 'Circ-*', all peptides from circRNA with or without additional variants will be included.

And when use 'Circ-+', peptides from circRNA with at least another variant source will be included.

Closes #906 

## Description
<!--- Briefly describe the changes included in this pull request  --->

Closes #...  <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
