### PR TITLE
Update pypi action to use new `release/v1` tag for the `v1.4.6` moPepGen release.

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -12,12 +12,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Build distribution
-        uses: uclahs-cds/tool-pypi-publish-action/build-distribution@8a59b1548652d33f0a224775805d9a39767f0605
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          package-name: mopepgen
+          python-version: "3.x"
+
+      - name: Install pypa/build
+        run: |
+          python3 -m pip install build --user
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python3 -m build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: "dist/"
 
   publish-to-pypi:
     name: Publish Python 🐍 distribution 📦 to PyPI
@@ -26,16 +40,18 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/${{ needs.build.outputs.package_name }}
+      url: https://pypi.org/p/mopepgen
     permissions:
       id-token: write
 
     steps:
-      - name: Checkout main
-        uses: actions/checkout@v2
-
-      - name: Publish to PyPI
-        uses: uclahs-cds/tool-pypi-publish-action/publish-to-pypi@8a59b1548652d33f0a224775805d9a39767f0605
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
         with:
-          package-name: mopepgen
-          url: https://upload.pypi.org/legacy/
+          name: python-package-distributions
+          path: "dist/"
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://upload.pypi.org/legacy/


### PR DESCRIPTION
I cherry-picked the change from https://github.com/uclahs-cds/package-moPepGen/pull/915 so we can test releasing moPepGen v1.4.6 without incorporating these changes:

```bash
| * 0f36ba6 - (12 hours ago) style (moPepGen): fixed style and added test files - zhuchcn
| * 8a80ce0 - (12 hours ago) doc (fuzzTest): fuzz test results updated - zhuchcn
| * 8f8e871 - (12 hours ago) doc (moPepGen): updated documentation for codon table and start codons - zhuchcn
| * 15a344d - (2 days ago) fix (fuzzTest): update cds limits again 2 - zhuchcn
| * c43b9eb - (2 days ago) fix (fuzzTest): update cds limits again - zhuchcn
| * 73e6937 - (2 days ago) fix (fuzzTest): cds start should be at least 3 nucleotide away from the cds end. - zhuchcn
| * 104d50b - (3 days ago) fix (callVariant): Fixed `callVariant` that during TVG alignment, node merged from multiple frameshifts which together go back to the origianl frame, was not recognized as `was_brige` in a bubble - zhuchcn
| * 3945e57 - (3 days ago) fix (bruteForce): when forcing initial M, the origianl amino acid was not removed.. - zhuchcn
| * 7cb903d - (4 days ago) fix (bruteForce): next and last orf start not found correctly - zhuchcn
| * d9d67fd - (4 days ago) fix (fuzzTest): Updated `fuzzTest` to pass codon tabel and start codons to `callVariant` and `bruteForce` - zhuchcn
| * 5dfa44e - (4 days ago) fix (bruteForce): Updated `bruteForce` to specify codon table and start codons. - zhuchcn
| * 8abce79 - (4 days ago) sylte (moPepGen): Updated the reference data loading function to directly return a `ReferenceData` object. - zhuchcn
| * c867ea6 - (4 days ago) style (moPepGen): style fix - zhuchcn
| * f2dd67f - (4 days ago) fix (PVG): Added `force_init_met` to `PeptideVariantGraph.call_variant_peptide` to control whether the initial amino acid should be forced to Methionine. - zhuchcn
| * 8249585 - (4 days ago) fix (moPepGen): 1. Added `--star-codons` and `--chr-star-codons` to specify start codons to use. 2. Fixed graph algorithms to use specified codon table and start codon 3. Fixed `GenomicAnnotationOnDisk` that when using on-the-fly indices, the `is_protein_coding` attributes of transcripts are not updated correctly. - zhuchcn
| * 2ffaf67 - (6 days ago) test (moPepGen): test case added for mtSNV and codon table - zhuchcn
| * de13564 - (8 days ago) test(TVG): test case added for translation with codon table - zhuchcn
| * fec0cb3 - (9 days ago) fix(moPepGen): fix pylint - zhuchcn
| * 87193b9 - (9 days ago) feat(downsampleReference): added codon table - zhuchcn
| * 7df6765 - (9 days ago) feat(moPepGen): Added the support for codon table for `callNovelORF` and `callAltTranslation`. - zhuchcn
| * 6b797a6 - (10 days ago) feat(callVariant): Added the support for codon table. - zhuchcn
| * 759a73c - (10 days ago) feat(generateIndex): Added `--codon-table` and `--chr-codon-table`. The former sets the codon table to use, and the latter overrides it for specific chromosomes. - zhuchcn
```