### PR TITLE
Add `--in-bubble-cap-step-down` to `callVariant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add `--in-bubble-cap-step-down` to `callVariant` for TVG in case of hypermutated regions.
 
+- Fixed `callVariant` that timeout error not caught when `--skip-failed` is given
+
 ## [1.5.0-rc1] - 2025-06-17
 
 - Added `--codon-table` and `--chr-codon-table`. The former sets the codon table to use, and the latter overrides it for specific chromosomes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.5.0-rc2] - 2025-06-19
+
+- Add `--in-bubble-cap-step-down` to `callVariant` for TVG in case of hypermutated regions.
+
 ## [1.5.0-rc1] - 2025-06-17
 
 - Added `--codon-table` and `--chr-codon-table`. The former sets the codon table to use, and the latter overrides it for specific chromosomes.

--- a/moPepGen/__init__.py
+++ b/moPepGen/__init__.py
@@ -8,7 +8,7 @@ import logging
 from . import constant
 
 
-__version__ = '1.5.0-rc1'
+__version__ = '1.5.0-rc2'
 
 ## Error messages
 ERROR_INDEX_IN_INTRON = 'The genomic index seems to be in an intron'

--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -14,6 +14,7 @@ import copy
 import json
 from typing import List, Set, TYPE_CHECKING, Dict, Tuple, Union
 from pathlib import Path
+import dataclasses
 from contextlib import ExitStack
 from pathos.pools import ParallelPool
 from moPepGen import svgraph, aa, seqvar, gtf, params, get_logger
@@ -28,7 +29,7 @@ if TYPE_CHECKING:
     from moPepGen.svgraph import ThreeFrameCVG, ThreeFrameTVG, PeptideVariantGraph
     from moPepGen.svgraph.VariantPeptideDict import AnnotatedPeptideLabel
     from moPepGen.gtf import GeneAnnotationModel
-    from moPepGen.params import CodonTableInfo
+    from moPepGen.params import CodonTableInfo, CleavageParams
 
 
 INPUT_FILE_FORMATS = ['.gvf']
@@ -111,6 +112,13 @@ def add_subparser_call_variant(subparsers:argparse._SubParsersAction):
         default=(2,),
         nargs='+',
         metavar='<number>'
+    )
+    p.add_argument(
+        '--in-bubble-cap-step-down',
+        type=int,
+        default=0,
+        metavar='<number>',
+        help='In bubble variant caps default step down.'
     )
     p.add_argument(
         '--min-nodes-to-collapse',
@@ -221,6 +229,7 @@ class VariantPeptideCaller():
             max_length=args.max_length,
             max_variants_per_node = args.max_variants_per_node[0],
             additional_variants_per_misc = args.additional_variants_per_misc[0],
+            in_bubble_cap_step_down=args.in_bubble_cap_step_down,
             min_nodes_to_collapse = args.min_nodes_to_collapse,
             naa_to_collapse = args.naa_to_collapse
         )
@@ -397,11 +406,11 @@ class VariantPeptideCaller():
             'timeout': self.args.timeout_seconds,
             'max_variants_per_node': tuple(self.args.max_variants_per_node),
             'additional_variants_per_misc': tuple(self.args.additional_variants_per_misc),
+            'in_bubble_cap_step_down': self.args.in_bubble_cap_step_down,
             'backsplicing_only': self.args.backsplicing_only,
             'coding_novel_orf': self.args.coding_novel_orf,
             'skip_failed': self.args.skip_failed
         }
-
 
 if TYPE_CHECKING:
     TypeDGraphs = Tuple[
@@ -439,6 +448,7 @@ def call_variant_peptides_wrapper(tx_id:str,
         save_graph:bool,
         coding_novel_orf:bool,
         skip_failed:bool,
+        tracer:TimeoutTracer,
         **kwargs
         ) -> CallVariantOutput:
     """ wrapper function to call variant peptides """
@@ -463,6 +473,7 @@ def call_variant_peptides_wrapper(tx_id:str,
     dgraphs:TypeDGraphs = (None, {}, {})
     pgraphs:TypePGraphs = (None, {}, {})
     success_flags = (True, True, True)
+    tracer.backbone = 'main'
     if variant_series.transcriptional:
         try:
             if not noncanonical_transcripts or \
@@ -477,13 +488,16 @@ def call_variant_peptides_wrapper(tx_id:str,
                     w2f=w2f_reassignment,
                     denylist=denylist,
                     save_graph=save_graph,
-                    coding_novel_orf=coding_novel_orf
+                    coding_novel_orf=coding_novel_orf,
+                    tracer=tracer
                 )
                 main_peptides = set(peptide_map.keys())
                 dgraphs = (dgraph, dgraphs[1], dgraphs[2])
                 pgraphs = (pgraph, pgraphs[1], pgraphs[2])
                 add_peptide_anno(peptide_map)
-        except:
+        except Exception as e:
+            if  isinstance(e, TimeoutError):
+                raise
             if skip_failed:
                 logger.warning('Variant peptides calling failed from %s', tx_id)
                 success_flags = (False, success_flags[1], success_flags[2])
@@ -491,6 +505,7 @@ def call_variant_peptides_wrapper(tx_id:str,
                 logger.error('Exception raised from %s', tx_id)
                 raise
 
+    tracer.backbone = 'fusion'
     exclude_variant_types = ['Fusion', 'Insertion', 'Deletion', 'Substitution', 'circRNA']
     for variant in variant_series.fusion:
         try:
@@ -513,12 +528,14 @@ def call_variant_peptides_wrapper(tx_id:str,
                 codon_table=codon_table, tx_seqs=tx_seqs, gene_seqs=gene_seqs,
                 cleavage_params=cleavage_params, max_adjacent_as_mnv=max_adjacent_as_mnv,
                 w2f_reassignment=w2f_reassignment, denylist=denylist, save_graph=save_graph,
-                coding_novel_orf=coding_novel_orf
+                coding_novel_orf=coding_novel_orf, tracer=tracer
             )
             dgraphs[1][variant.id] = dgraph
             pgraphs[1][variant.id] = pgraph
             add_peptide_anno(peptide_map)
-        except:
+        except Exception as e:
+            if  isinstance(e, TimeoutError):
+                raise
             if skip_failed:
                 logger.warning(
                     'Variant peptides calling failed from %s with fusion: %s',
@@ -532,6 +549,7 @@ def call_variant_peptides_wrapper(tx_id:str,
                 )
                 raise
 
+    tracer.backbone = 'circRNA'
     if main_peptides:
         denylist.update([str(x) for x in main_peptides])
     for circ_model in variant_series.circ_rna:
@@ -541,10 +559,13 @@ def call_variant_peptides_wrapper(tx_id:str,
                 cleavage_params=cleavage_params, codon_table=codon_table,
                 max_adjacent_as_mnv=max_adjacent_as_mnv,
                 w2f_reassignment=w2f_reassignment, denylist=denylist,
-                save_graph=save_graph, backsplicing_only=backsplicing_only
+                save_graph=save_graph, backsplicing_only=backsplicing_only,
+                tracer=tracer
             )
 
-        except:
+        except Exception as e:
+            if  isinstance(e, TimeoutError):
+                raise
             if skip_failed:
                 logger.warning(
                     'Variant peptides calling failed from %s with circRNA: %s',
@@ -562,33 +583,49 @@ def call_variant_peptides_wrapper(tx_id:str,
 
     return peptide_anno, tx_id, dgraphs, pgraphs, success_flags
 
+@dataclasses.dataclass
+class TimeoutTracer:
+    """ Tracking time out """
+    backbone:str = None
+    graph:str = None
+
 def caller_reducer(dispatch):
     """ wrapper for ParallelPool. Also reduces the complexity if the run is timed out. """
     max_variants_per_node = dispatch['max_variants_per_node']
     additional_variants_per_misc = dispatch['additional_variants_per_misc']
+    in_bubble_cap_step_down = dispatch['in_bubble_cap_step_down']
     tx_id = dispatch['tx_id']
+    tracer = TimeoutTracer()
+    dispatch['tracer'] = tracer
     while True:
         try:
             return call_variant_peptides_wrapper(**dispatch)
         except TimeoutError as e:
             new_dispatch = copy.copy(dispatch)
-            p = copy.copy(new_dispatch['cleavage_params'])
-            max_variants_per_node = max_variants_per_node[1:]
-            if len(max_variants_per_node) == 0:
-                max_variants_per_node = (p.max_variants_per_node - 1, )
-                if max_variants_per_node[0] <= 0:
-                    raise ValueError(f"Failed to finish transcript: {tx_id}") from e
-            additional_variants_per_misc = additional_variants_per_misc[1:]
-            if len(additional_variants_per_misc) == 0:
-                additional_variants_per_misc = (0,)
+            p:CleavageParams = copy.copy(new_dispatch['cleavage_params'])
+            if tracer.graph == 'TVG':
+                in_bubble_cap_step_down += 1
+            else:
+                max_variants_per_node = max_variants_per_node[1:]
+                if len(max_variants_per_node) == 0:
+                    max_variants_per_node = (p.max_variants_per_node - 1, )
+                    if max_variants_per_node[0] <= 0:
+                        raise ValueError(f"Failed to finish transcript: {tx_id}") from e
+                additional_variants_per_misc = additional_variants_per_misc[1:]
+                if len(additional_variants_per_misc) == 0:
+                    additional_variants_per_misc = (0,)
             p.max_variants_per_node = max_variants_per_node[0]
             p.additional_variants_per_misc = additional_variants_per_misc[0]
+            p.in_bubble_cap_step_down = in_bubble_cap_step_down
             new_dispatch['cleavage_params'] = p
+            new_dispatch['tracer'] = TimeoutTracer()
             dispatch = new_dispatch
             get_logger().warning(
                 "Transcript %s timed out. Retry with "
-                "--max-variants-per-node %i --additional-variants-per-misc %i",
-                tx_id, p.max_variants_per_node, p.additional_variants_per_misc
+                "--max-variants-per-node %i --additional-variants-per-misc %i"
+                "and `--in-bubble-cap-step-down` %i",
+                tx_id, p.max_variants_per_node, p.additional_variants_per_misc,
+                in_bubble_cap_step_down
             )
 
 def call_variant_peptide(args:argparse.Namespace) -> None:
@@ -719,11 +756,14 @@ def call_peptide_main(tx_id:str, tx_variants:List[seqvar.VariantRecord],
         gene_seqs:Dict[str, dna.DNASeqRecordWithCoordinates],
         cleavage_params:params.CleavageParams,
         max_adjacent_as_mnv:bool, truncate_sec:bool, w2f:bool,
-        denylist:Set[str], save_graph:bool, coding_novel_orf:bool
+        denylist:Set[str], save_graph:bool, coding_novel_orf:bool,
+        tracer:TimeoutTracer
         ) -> TypeCallPeptideReturnData:
     """ Call variant peptides for main variants (except cirRNA). """
     tx_model = ref.anno.transcripts[tx_id]
     tx_seq = tx_seqs[tx_id]
+
+    tracer.graph = 'TVG'
 
     dgraph = svgraph.ThreeFrameTVG(
         seq=tx_seq,
@@ -747,6 +787,8 @@ def call_peptide_main(tx_id:str, tx_variants:List[seqvar.VariantRecord],
         table=codon_table.codon_table,
         start_codons=codon_table.start_codons
     )
+
+    tracer.graph = 'PVG'
 
     pgraph.create_cleavage_graph()
 
@@ -784,7 +826,7 @@ def call_peptide_fusion(variant:seqvar.VariantRecord,
         gene_seqs:Dict[str, dna.DNASeqRecordWithCoordinates],
         cleavage_params:params.CleavageParams, max_adjacent_as_mnv:bool,
         w2f_reassignment:bool, denylist:Set[str], save_graph:bool,
-        coding_novel_orf:bool
+        coding_novel_orf:bool, tracer:TimeoutTracer
         ) -> TypeCallPeptideReturnData:
     """ Call variant peptides for fusion """
     tx_id = variant.location.seqname
@@ -792,6 +834,8 @@ def call_peptide_fusion(variant:seqvar.VariantRecord,
     tx_seq = tx_seqs[tx_id]
     tx_seq = tx_seq[:variant.location.start]
     donor_tx_id = variant.accepter_transcript_id
+
+    tracer.graph = 'TVG'
 
     orf_start = tx_seq.orf.start + 3 if tx_seq.orf else 3
     if variant.location.start < orf_start:
@@ -829,6 +873,9 @@ def call_peptide_fusion(variant:seqvar.VariantRecord,
         table=codon_table.codon_table,
         start_codons=codon_table.start_codons
     )
+
+    tracer.graph = 'PVG'
+
     pgraph.create_cleavage_graph()
 
     if tx_model.is_protein_coding:
@@ -862,7 +909,7 @@ def call_peptide_circ_rna(record:circ.CircRNAModel,
         codon_table:CodonTableInfo,
         cleavage_params:params.CleavageParams, max_adjacent_as_mnv:bool,
         backsplicing_only:bool, w2f_reassignment:bool, denylist:Set[str],
-        save_graph:bool
+        save_graph:bool, tracer:TimeoutTracer
         )-> TypeCallPeptideReturnData:
     """ Call variant peptides from a given circRNA """
     gene_id = record.gene_id
@@ -871,6 +918,8 @@ def call_peptide_circ_rna(record:circ.CircRNAModel,
     circ_seq = record.get_circ_rna_sequence(gene_seq)
     for loc in circ_seq.locations:
         loc.ref.seqname = record.id
+
+    tracer.graph = 'TVG'
 
     # Alternative splicing should not be included. Alternative splicing
     # represented as Insertion, Deletion or Substitution.
@@ -910,6 +959,9 @@ def call_peptide_circ_rna(record:circ.CircRNAModel,
         table=codon_table.codon_table,
         start_codons=codon_table.start_codons
     )
+
+    tracer.graph = 'PVG'
+
     pgraph.create_cleavage_graph()
     peptide_map = pgraph.call_variant_peptides(
         denylist=denylist, circ_rna=record, backsplicing_only=backsplicing_only,

--- a/moPepGen/params.py
+++ b/moPepGen/params.py
@@ -36,7 +36,8 @@ class CleavageParams():
     def __init__(self, enzyme:str=None, exception:str=None, miscleavage:int=2,
             min_mw:int=500, min_length:int=7, max_length:int=25,
             max_variants_per_node:int=7, additional_variants_per_misc:int=2,
-            min_nodes_to_collapse:int=30, naa_to_collapse:int=5):
+            in_bubble_cap_step_down:int=0, min_nodes_to_collapse:int=30,
+            naa_to_collapse:int=5):
         """ constructor """
         self.enzyme = enzyme
         self.exception = exception
@@ -46,6 +47,7 @@ class CleavageParams():
         self.max_length = max_length
         self.max_variants_per_node = max_variants_per_node
         self.additional_variants_per_misc = additional_variants_per_misc
+        self.in_bubble_cap_step_down = in_bubble_cap_step_down
         self.min_nodes_to_collapse = min_nodes_to_collapse
         self.naa_to_collapse = naa_to_collapse
         if self.exception == 'auto':

--- a/moPepGen/svgraph/ThreeFrameTVG.py
+++ b/moPepGen/svgraph/ThreeFrameTVG.py
@@ -1546,25 +1546,28 @@ class ThreeFrameTVG():
         return len(variants) > max_in_bubble_variants
 
     @staticmethod
-    def get_max_in_bubble_variants(n:int) -> int:
+    def get_max_in_bubble_variants(n:int, down_steps:int=0) -> int:
         """ Get the `max_in_bubble_variants` based on the total number of variants
         in a variant bubble. The values are set so the number of combinations to
         consider won't be too much more than 5,000. """
-        if n <= 12:
-            return -1
-        if n <= 14:
-            return 7
-        if n <= 15:
-            return 6
-        if n <= 16:
-            return 5
-        if n <= 21:
-            return 4
-        if n <= 34:
-            return 3
-        if n <= 100:
-            return 2
-        return 1
+        caps = [
+            (12, -1),
+            (14, 7),
+            (15, 6),
+            (16, 5),
+            (21, 4),
+            (34, 3),
+            (100, 2),
+            (float('inf'), 1),
+        ]
+        for i, (threshold, _) in enumerate(caps):
+            if n <= threshold:
+                cap_index = i
+                break
+        else:
+            cap_index = len(caps) - 1
+        j = min(cap_index + down_steps, len(caps) - 1)
+        return caps[j][1]
 
     def align_variants(self, node:TVGNode) -> Tuple[TVGNode, TVGNode]:
         r""" Aligns all variants at that overlaps to the same start and end
@@ -1594,7 +1597,10 @@ class ThreeFrameTVG():
         for member in members:
             member_variants.update([v.variant.id for v in member.variants])
 
-        max_in_bubble_variants = self.get_max_in_bubble_variants(len(member_variants))
+        max_in_bubble_variants = self.get_max_in_bubble_variants(
+            n=len(member_variants),
+            down_steps=self.cleavage_params.in_bubble_cap_step_down
+        )
 
         if len(member_variants) >= 13:
             get_logger().warning(

--- a/test/integration/test_call_variant_peptides.py
+++ b/test/integration/test_call_variant_peptides.py
@@ -36,6 +36,7 @@ def create_base_args() -> argparse.Namespace:
     args.w2f_reassignment = False
     args.max_variants_per_node = [7]
     args.additional_variants_per_misc = [2]
+    args.in_bubble_cap_step_down = 0
     args.min_nodes_to_collapse = 30
     args.naa_to_collapse = 5
     args.inclusion_biotypes = None


### PR DESCRIPTION
…or TVG in case of hypermutated regions.

## Description
<!--- Briefly describe the changes included in this pull request  --->

Time out only adjust down the parameters for PVG, so for those the TVG gets stuck will not proceed.

Adding `--in-bubble-cap-step-down` so the handle of hypermutated regions of TVG will also adjust down.

Closes #...  <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
