### PR TITLE
Update parseVEP to support VCF format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fixed `callVariant` that timeout error not caught when `--skip-failed` is given
 
+- Added support of VEP VCF files in `parseVEP'
+
 ## [1.5.0-rc1] - 2025-06-17
 
 - Added `--codon-table` and `--chr-codon-table`. The former sets the codon table to use, and the latter overrides it for specific chromosomes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fixed `callVariant` that timeout error not caught when `--skip-failed` is given
 
-- Added support of VEP VCF files in `parseVEP'
+- Added support of VEP VCF files in `parseVEP`
 
 ## [1.5.0-rc1] - 2025-06-17
 

--- a/docs/parse-vep.md
+++ b/docs/parse-vep.md
@@ -29,7 +29,11 @@ moPepGen relies on Ensembl Variant Effect Predictor ([VEP](https://www.ensembl.o
 
 Please refer to the official [VEP Tutorial](https://www.ensembl.org/info/docs/tools/vep/script/vep_tutorial.html) for instructions on downloading, installing and running VEP. The key is to ensure that the annotation version used in `VEP` is the same as the one you would like to use with moPepGen.
 
-`parseVEP` currently only supports the TSV output of `VEP`, please set the suffix of `--output_file` to `.tsv` to ensure the correct format is outputted by `VEP`. `VEP`'s default output format is tab-delimited, and the `--tab` option adds extra columns to the output that are not used by moPepGen. So including or excluding `--tab` will not impact the results of moPepGen.
+`parseVEP` supports both the TSV and VCF format of output of `VEP`. For TSV, `VEP`'s default is tab-delimited, and the `--tab` option adds extra columns to the output that are not used by moPepGen. So including or excluding `--tab` will not impact the results of moPepGen. As for `VCF`, the `CSQ` info field is parsed, and the default format is expected, containing the following fields:
+
+```
+Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID
+```
 
 ### Using an Ensembl GTF
 

--- a/docs/parse-vep.md
+++ b/docs/parse-vep.md
@@ -35,6 +35,8 @@ Please refer to the official [VEP Tutorial](https://www.ensembl.org/info/docs/to
 Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID
 ```
 
+When using VCF format, all records are processed and the sample columns are not utilized. For multi-sample VCF files, consider split it before calling `parseVEP`.
+
 ### Using an Ensembl GTF
 
 `VEP` automatically uses an Ensembl GTF for annotation. Please ensure that the release version and genome build version is consistent with the references files downloaded. This is available in the name of the cache in output headers (for example, `107_GRCh38`).

--- a/docs/partials/_args_codon_table.md
+++ b/docs/partials/_args_codon_table.md
@@ -42,7 +42,7 @@ The chromosome names must be specified correctly, same as what used in the genom
 --codon-table Standard \
 --chr-codon-table 'chrM:SGC1' \
 --start-codons 'ATG' \
---chr-start-codongs 'chrM:ATG,ATA,ATT
+--chr-start-codons 'chrM:ATG,ATA,ATT
 ```
 
 or
@@ -52,5 +52,5 @@ or
 --codon-table Standard \
 --chr-codon-table 'MT:SGC1' \
 --start-codons 'ATG' \
---chr-start-codongs 'MT:ATG,ATA,ATT
+--chr-start-codons 'MT:ATG,ATA,ATT
 ```

--- a/moPepGen/cli/parse_vep.py
+++ b/moPepGen/cli/parse_vep.py
@@ -15,7 +15,7 @@ from moPepGen import seqvar, get_logger
 from moPepGen.cli import common
 
 
-INPUT_FILE_FORMATS = ['.tsv', '.txt', '.tsv.gz', '.txt.gz']
+INPUT_FILE_FORMATS = ['.tsv', '.txt', '.tsv.gz', '.txt.gz', '.vcf', '.vcf.gz']
 OUTPUT_FILE_FORMATS = ['.gvf']
 
 if TYPE_CHECKING:
@@ -100,15 +100,18 @@ def parse_vep(args:argparse.Namespace) -> None:
     tally = TallyTable(logger)
 
     for vep_file in vep_files:
+        if '.vcf' in vep_file.suffixes:
+            format = 'vcf'
+        else:
+            format = 'tsv'
         opener = gzip.open if vep_file.suffix == '.gz' else open
         with opener(vep_file, 'rt') as handle:
-            for record in VEPParser.parse(handle):
+            for record in VEPParser.parse(handle, format=format):
                 tally.total += 1
                 transcript_id = record.feature
 
                 if transcript_id not in vep_records:
                     vep_records[transcript_id] = []
-
 
                 try:
                     record = record.convert_to_variant_record(anno, genome)

--- a/moPepGen/svgraph/VariantPeptideTable.py
+++ b/moPepGen/svgraph/VariantPeptideTable.py
@@ -88,7 +88,7 @@ class VariantPeptideTable:
                 fields = dict(zip(VARIANT_PEPTIDE_TABLE_HEADERS, line.split('\t')))
                 if seq != fields['sequence']:
                     raise ValueError(
-                        f"Peptide ({seq}) does not match with table record ({fields[0]})."
+                        f"Peptide ({seq}) does not match with table record ({fields['sequence']})."
                     )
                 header = fields['header']
                 label = anno.setdefault(header, AnnotatedPeptideLabel(label=header, segments=[]))

--- a/test/files/vep/snp.vcf
+++ b/test/files/vep/snp.vcf
@@ -1,0 +1,17 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr22,length=5448>
+##contig=<ID=chrM,length=71>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	UCLA0001
+chr22	611	.	T	A	.	PASS	.	GT	0/1
+chr22	1157	.	G	A	.	PASS	.	GT	0/1
+chr22	1179	.	C	T	.	PASS	.	GT	0/1
+chr22	1205	.	G	A	.	PASS	.	GT	0/1
+chr22	1426	.	G	A	.	PASS	.	GT	0/1
+chr22	4864	.	G	A	.	PASS	.	GT	0/1
+chr22	4764	.	G	A	.	PASS	.	GT	0/1
+chr22	4164	.	G	A	.	PASS	.	GT	0/1
+chrM	41	.	G	A	.	PASS	.	GT	0/1
+chrM	48	.	C	A	.	PASS	.	GT	0/1
+chrM	50	.	C	T	.	PASS	.	GT	0/1

--- a/test/files/vep/vep_snp.vcf
+++ b/test/files/vep/vep_snp.vcf
@@ -1,0 +1,18 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr22,length=5448>
+##contig=<ID=chrM,length=71>
+##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|SOURCE|GENCODE">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	UCLA0001
+chr22	611	.	T	A	.	PASS	CSQ=A|synonymous_variant|LOW|RIBC2|ENSG00000128408.9|Transcript|ENST00000614167.2|protein_coding|3/6||||611|417|139|T|acT/acA|||1||||GENCODE|,A|intron_variant|MODIFIER|RIBC2|ENSG00000128408.9|Transcript|ENST00000614168.2|protein_coding||2/4||||||||||1||||GENCODE|	GT	0/1
+chr22	1157	.	G	A	.	PASS	CSQ=A|synonymous_variant|LOW|RIBC2|ENSG00000128408.9|Transcript|ENST00000614167.2|protein_coding|5/6||||929|735|245|G|ggG/ggA|||1||||GENCODE|,A|intron_variant|MODIFIER|RIBC2|ENSG00000128408.9|Transcript|ENST00000614168.2|protein_coding||4/4||||||||||1||||GENCODE|	GT	0/1
+chr22	1179	.	C	T	.	PASS	CSQ=T|stop_gained|HIGH|RIBC2|ENSG00000128408.9|Transcript|ENST00000614167.2|protein_coding|5/6||||951|757|253|Q/*|Cag/Tag|||1||||GENCODE|,T|intron_variant|MODIFIER|RIBC2|ENSG00000128408.9|Transcript|ENST00000614168.2|protein_coding||4/4||||||||||1||||GENCODE|	GT	0/1
+chr22	1205	.	G	A	.	PASS	CSQ=A|synonymous_variant|LOW|RIBC2|ENSG00000128408.9|Transcript|ENST00000614167.2|protein_coding|5/6||||977|783|261|R|cgG/cgA|||1||||GENCODE|,A|intron_variant|MODIFIER|RIBC2|ENSG00000128408.9|Transcript|ENST00000614168.2|protein_coding||4/4||||||||||1||||GENCODE|	GT	0/1
+chr22	1426	.	G	A	.	PASS	CSQ=A|missense_variant|MODERATE|RIBC2|ENSG00000128408.9|Transcript|ENST00000614167.2|protein_coding|6/6||||1198|1004|335|R/H|cGc/cAc|||1||||GENCODE|,A|synonymous_variant|LOW|RIBC2|ENSG00000128408.9|Transcript|ENST00000614168.2|protein_coding|5/5||||914|720|240|T|acG/acA|||1||||GENCODE|	GT	0/1
+chr22	4864	.	G	A	.	PASS	CSQ=A|missense_variant|MODERATE|SCARF2|ENSG00000244486.9|Transcript|ENST00000622235.5|protein_coding|1/11||||100|29|10|A/V|gCg/gTg|||-1||||GENCODE|	GT	0/1
+chr22	4764	.	G	A	.	PASS	CSQ=A|synonymous_variant|LOW|SCARF2|ENSG00000244486.9|Transcript|ENST00000622235.5|protein_coding|1/11||||200|129|43|P|ccC/ccT|||-1||||GENCODE|	GT	0/1
+chr22	4164	.	G	A	.	PASS	CSQ=A|synonymous_variant|LOW|SCARF2|ENSG00000244486.9|Transcript|ENST00000622235.5|protein_coding|4/11||||800|729|243|Y|taC/taT|||-1||||GENCODE|	GT	0/1
+chrM	41	.	G	A	.	PASS	CSQ=A|missense_variant|MODERATE|MT-TF|ENSG00000210049.1|Transcript|ENST00000387314.1|.|1/1||||41|43|15|V/I|Gtt/Att|||1||||GENCODE|	GT	0/1
+chrM	48	.	C	A	.	PASS	CSQ=A|missense_variant|MODERATE|MT-TF|ENSG00000210049.1|Transcript|ENST00000387314.1|.|1/1||||48|50|17|T/K|aCg/aAg|||1||||GENCODE|	GT	0/1
+chrM	50	.	C	T	.	PASS	CSQ=T|missense_variant|MODERATE|MT-TF|ENSG00000210049.1|Transcript|ENST00000387314.1|.|1/1||||50|52|18|R/C|Cgc/Tgc|||1||||GENCODE|	GT	0/1

--- a/test/integration/test_parse_vep.py
+++ b/test/integration/test_parse_vep.py
@@ -80,3 +80,15 @@ class TestParseVEP(TestCaseIntegration):
         expected = {'vep.gvf'}
         self.assertEqual(files, expected)
         self.assert_gvf_order(args.output_path, args.annotation_gtf)
+
+    def test_parse_vep_vcf(self):
+        """ Test parsing VEP output in VCF format into GVF """
+        args = self.create_base_args()
+        args.input_path = [
+            self.data_dir/'vep'/'vep_snp.vcf'
+        ]
+        cli.parse_vep(args)
+        files = {str(file.name) for file in self.work_dir.glob('*')}
+        expected = {'vep.gvf'}
+        self.assertEqual(files, expected)
+        self.assert_gvf_order(args.output_path, args.annotation_gtf)


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

VCF format is now supported by parseVEP, using the VEP annotation results stored in the `CSQ` info field.

The sample columns are not used, and the whole VCF file is treated as one "sample".

Closes #896   <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
