### PR TITLE
Add a timeout error mechanism for `in_bubble_variant_step_down`

### DIFF
--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -610,6 +610,11 @@ def caller_reducer(dispatch):
             p:CleavageParams = copy.copy(new_dispatch['cleavage_params'])
             if tracer.graph == 'TVG':
                 in_bubble_cap_step_down += 1
+                if in_bubble_cap_step_down > len(ThreeFrameTVG.VARIANT_BUBBLE_CAPS):
+                    raise ValueError(
+                        f"Failed to finish transcript: {tx_id} "
+                        f"with in_bubble_cap_step_down: {in_bubble_cap_step_down}"
+                    ) from e
             else:
                 max_variants_per_node = max_variants_per_node[1:]
                 if len(max_variants_per_node) == 0:

--- a/moPepGen/cli/call_variant_peptide.py
+++ b/moPepGen/cli/call_variant_peptide.py
@@ -21,13 +21,14 @@ from pathos.pools import ParallelPool
 from moPepGen import svgraph, aa, seqvar, gtf, params, get_logger
 from moPepGen.cli import common
 from moPepGen.SeqFeature import FeatureLocation, SeqFeature
+from moPepGen.svgraph import ThreeFrameTVG
 
 
 if TYPE_CHECKING:
     from logging import Logger
     from Bio.Seq import Seq
     from moPepGen import dna, circ
-    from moPepGen.svgraph import ThreeFrameCVG, ThreeFrameTVG, PeptideVariantGraph
+    from moPepGen.svgraph import ThreeFrameCVG, PeptideVariantGraph
     from moPepGen.svgraph.VariantPeptideDict import AnnotatedPeptideLabel
     from moPepGen.gtf import GeneAnnotationModel
     from moPepGen.params import CodonTableInfo, CleavageParams

--- a/moPepGen/svgraph/ThreeFrameTVG.py
+++ b/moPepGen/svgraph/ThreeFrameTVG.py
@@ -1545,21 +1545,22 @@ class ThreeFrameTVG():
                 variants.add(variant.variant)
         return len(variants) > max_in_bubble_variants
 
-    @staticmethod
-    def get_max_in_bubble_variants(n:int, down_steps:int=0) -> int:
+    VARIANT_BUBBLE_CAPS:List[Tuple[Union[int, float],int]] = [
+        (12, -1),
+        (14, 7),
+        (15, 6),
+        (16, 5),
+        (21, 4),
+        (34, 3),
+        (100, 2),
+        (float('inf'), 1),
+    ]
+
+    def get_max_in_bubble_variants(self, n:int, down_steps:int=0) -> int:
         """ Get the `max_in_bubble_variants` based on the total number of variants
         in a variant bubble. The values are set so the number of combinations to
         consider won't be too much more than 5,000. """
-        caps = [
-            (12, -1),
-            (14, 7),
-            (15, 6),
-            (16, 5),
-            (21, 4),
-            (34, 3),
-            (100, 2),
-            (float('inf'), 1),
-        ]
+        caps = self.VARIANT_BUBBLE_CAPS
         for i, (threshold, _) in enumerate(caps):
             if n <= threshold:
                 cap_index = i

--- a/moPepGen/svgraph/ThreeFrameTVG.py
+++ b/moPepGen/svgraph/ThreeFrameTVG.py
@@ -26,21 +26,52 @@ if TYPE_CHECKING:
     from moPepGen.seqvar import VariantRecord
 
 class ThreeFrameTVG():
-    """ Defines the DAG data structure for the transcript and its variants.
+    """
+    Defines the DAG data structure for the transcript and its variants.
 
     Attributes:
-        seq (DNASeqRecordWithCoordinates): The original sequence of the
-            transcript (reference).
-        root (TVGNode): The root of the graph. The sequence of the root node
-            must be None.
-        reading_frames (List[TVGNode]): List of three null nodes. Each node is
-            the root to the subgraph of the corresponding reading frame.
-        has_known_orf (bool): whether
-        cds_start_nf (bool)
-        mrna_end_nf (bool)
-        global_variant (VariantRecord)
-        id (str)
+        seq (DNASeqRecordWithCoordinates): The original sequence of the transcript
+            (reference).
+        id (str): Unique identifier for the transcript variant graph.
+        root (TVGNode): The root of the graph. The sequence of the root node must
+            be None.
+        reading_frames (List[TVGNode]): List of three null nodes. Each node is the
+            root to the subgraph of the corresponding reading frame.
+        cds_start_nf (bool): Indicates if the CDS start is not found.
+        has_known_orf (bool): Whether the transcript has a known open reading frame
+            (ORF).
+        mrna_end_nf (bool): Indicates if the mRNA end is not found.
+        global_variant (VariantRecord): The global variant record associated with
+            the graph.
+        subgraphs (SubgraphTree): The tree structure managing subgraphs for variant
+            bubbles and alternative splicing.
+        hypermutated_region_warned (bool): Whether a warning for hypermutated regions
+            has been issued.
+        cleavage_params (CleavageParams): Parameters for peptide cleavage (e.g.,
+            enzyme type).
+        gene_id (str): The gene identifier associated with the transcript.
+        sect_variants (List[VariantRecordWithCoordinate]): List of selenocysteine
+            truncation variants.
+        max_adjacent_as_mnv (int): Maximum number of adjacent variants to merge as
+            multi-nucleotide variants (MNV).
+
+    Constants:
+        VARIANT_BUBBLE_CAPS (List[Tuple[Union[int, float], int]]):
+            Caps for in-bubble variants to consider per combination used in
+            hypermutated regions.
     """
+
+    VARIANT_BUBBLE_CAPS:List[Tuple[Union[int, float],int]] = [
+        (12, -1),
+        (14, 7),
+        (15, 6),
+        (16, 5),
+        (21, 4),
+        (34, 3),
+        (100, 2),
+        (float('inf'), 1),
+    ]
+
     def __init__(self, seq:Union[DNASeqRecordWithCoordinates,None],
             _id:str, root:TVGNode=None, reading_frames:List[TVGNode]=None,
             cds_start_nf:bool=False, has_known_orf:bool=None,
@@ -1544,17 +1575,6 @@ class ThreeFrameTVG():
             for variant in node.variants:
                 variants.add(variant.variant)
         return len(variants) > max_in_bubble_variants
-
-    VARIANT_BUBBLE_CAPS:List[Tuple[Union[int, float],int]] = [
-        (12, -1),
-        (14, 7),
-        (15, 6),
-        (16, 5),
-        (21, 4),
-        (34, 3),
-        (100, 2),
-        (float('inf'), 1),
-    ]
 
     def get_max_in_bubble_variants(self, n:int, down_steps:int=0) -> int:
         """ Get the `max_in_bubble_variants` based on the total number of variants


### PR DESCRIPTION
…down

## Description
<!--- Briefly describe the changes included in this pull request  --->

Closes #930   <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
