### PR TITLE
Fixed that Protein Sequence IDs not Recognized in EMSEBL Style for GRCh37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Added `--skip-failed` to `parseREDItools`
 
+- Fixed that ENSEMBL GRCh37 style IDs not recognized for translate FASTA. #941
+
 ## [1.5.0-rc1] - 2025-06-17
 
 - Added `--codon-table` and `--chr-codon-table`. The former sets the codon table to use, and the latter overrides it for specific chromosomes.

--- a/moPepGen/aa/AminoAcidSeqRecord.py
+++ b/moPepGen/aa/AminoAcidSeqRecord.py
@@ -122,7 +122,7 @@ class AminoAcidSeqRecord(SeqRecord):
         """ Infers the gene, transcript, and protein ID from description base
         on the ENSEMBL format
         """
-        p = r'^(?P<protein_id>.+) pep (\bchromosome\b|\bsupercontig\b|\bscaffold\b):' +\
+        p = r'^(?P<protein_id>.+?) pep(?::[a-zA-Z0-9_,]+)? (\bchromosome\b|\bsupercontig\b|\bscaffold\b):' +\
             r'(?P<genome_build>.+?):(?P<chromosome>.+?):(?P<position>\d+:\d+):(?P<strand>.+) ' +\
             r'gene:(?P<gene_id>.+) transcript:(?P<transcript_id>\S+) .+'
 

--- a/test/unit/test_aa.py
+++ b/test/unit/test_aa.py
@@ -90,6 +90,23 @@ class TestAminoAcidSeqRecord(unittest.TestCase):
         with self.assertRaises(ValueError):
             seq.infer_ids_ensembl()
 
+    def test_nfer_ids_ensembl_case3(self):
+        """ Test that IDs are infered correctly with ENSEMBL style for GRCh37. """
+        seq = aa.AminoAcidSeqRecord(
+            seq=Seq('GTGG'),
+            _id='ENSP00000488240.1',
+            name='ENSP00000488240.1',
+            description='ENSP00000488240 pep:known chromosome:GRCh37:CHR_HSCHR7_2_'
+            'CTG6:142847306:142847317:1 gene:ENSG00000282253 transcript:ENST'
+            '00000631435 gene_biotype:TR_D_gene transcript_biotype:TR_D_gene'
+            ' gene_symbol:TRBD1 description:T cell receptor beta diversity 1 ['
+            'Source:HGNC Symbol;Acc:HGNC:12158]'
+        )
+        seq.infer_ids_ensembl()
+        self.assertEqual(seq.protein_id, 'ENSP00000488240')
+        self.assertEqual(seq.transcript_id, 'ENST00000631435')
+        self.assertEqual(seq.gene_id, 'ENSG00000282253')
+
     def test_infer_ids_gencode_case1(self):
         """ Test that ids are infered correctly with GENCODE style. """
         header = 'ENSP00000493376.2|ENST00000641515.2|ENSG00000186092.6|OTTH'+\


### PR DESCRIPTION
## Description
<!--- Briefly describe the changes included in this pull request  --->

Closes #941   <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
